### PR TITLE
pre-populate the model version and post-process function after model selection

### DIFF
--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -182,10 +182,31 @@ class Predict extends React.Component {
     this.predict();
   }
 
+  preselectModelConfig(event) {
+    const model = event.target.value.toLowerCase();
+    let postProcess = '';
+    if (model.indexOf('deepcell') !== -1) {
+      postProcess = 'deepcell';
+    } else if (model.indexOf('watershed') !== -1) {
+      postProcess = 'watershed';
+    } else if (model.indexOf('mibi') !== -1) {
+      postProcess = 'mibi';
+    }
+    this.setState({
+      postprocess: postProcess,
+      version: this.state.models[event.target.value][0]
+    });
+  }
+
   handleChange(event) {
     !this.isCancelled && this.setState({
       [event.target.name]: event.target.value
     });
+    // if updating a model, default to the first version
+    // and check if the transform/postprocessing is in the name
+    if (event.target.name === 'model') {
+      this.preselectModelConfig(event);
+    }
   }
 
   render() {


### PR DESCRIPTION
Once the User selects the model name, the app will pre-select the first model version in the list as well as a postprocessing function (if that postprocessing function is in the name of the model).