### PR TITLE
Adding component ids

### DIFF
--- a/src/FileUpload/FileUpload.js
+++ b/src/FileUpload/FileUpload.js
@@ -37,7 +37,7 @@ class FileUpload extends Component {
     //JSX that will be returned to the User's View
     return (
       <div className='dropzone'>
-        <Dropzone className='dropzoneCSS' accept='image/*,application/zip' onDrop={this.onDrop.bind(this)} >
+        <Dropzone name="imageUploadInput" className='dropzoneCSS' accept='image/*,application/zip' onDrop={this.onDrop.bind(this)} >
           <p className='uploadInstructions'>{ this.props.infoText }</p>
           <p className='uploadUnder'>Drag and Drop your files here or <span>click</span> to browse.</p>
           <div className='acceptedFiles'>

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -332,7 +332,7 @@ class Predict extends React.Component {
               : null }
 
             { !this.state.submitted ?
-              <Grid item lg style={{'paddingTop': '1em'}}>
+              <Grid id='submitButtonWrapper' item lg style={{'paddingTop': '1em'}}>
                 <Button
                   id='submitButton'
                   variant='contained'

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -252,6 +252,7 @@ class Predict extends React.Component {
                   <FormControl className={classes.formControl}>
                     <FormLabel>Select A Model</FormLabel>
                     <Select
+                      id='modelSelection'
                       value={this.state.model}
                       input={<Input name='model' id='model-placeholder' placeholder='' />}
                       onChange={this.handleChange}

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -252,7 +252,6 @@ class Predict extends React.Component {
                   <FormControl className={classes.formControl}>
                     <FormLabel>Select A Model</FormLabel>
                     <Select
-                      id='modelSelection'
                       value={this.state.model}
                       input={<Input name='model' id='model-placeholder' placeholder='' />}
                       onChange={this.handleChange}
@@ -335,6 +334,7 @@ class Predict extends React.Component {
             { !this.state.submitted ?
               <Grid item lg style={{'paddingTop': '1em'}}>
                 <Button
+                  id='submitButton'
                   variant='contained'
                   onClick={this.handleSubmit}
                   size='large'


### PR DESCRIPTION
There are some elements that Selenium (running in the `kiosk-benchmarking` pod) needs to be able to identify reliably. Assigning ids to these components is the simplest way to accomplish that.