### PR TITLE
attempting to write upload timestamp

### DIFF
--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -18,6 +18,7 @@ async function predict(req, res) {
       'file_name', `${prefix}/${req.body.imageName}`,
       'postprocess_function', req.body.postprocess_function,
       'cuts', req.body.cuts,
+      'timestamp_upload', Date.now(),
       'status', 'new'
     ], (err, redisRes) => {
       if (err) throw err;


### PR DESCRIPTION
The Express server now writes a new field, "timestamp_upload", when adding a new Redis entry. "timestamp_upload" is denoted in seconds since 1970.