### PR TITLE
Redis queue for processing

### DIFF
--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -21,8 +21,8 @@ async function predict(req, res) {
       'original_name', req.body.imageName,
       'postprocess_function', req.body.postprocess_function,
       'status', 'new',
-      'created_at', Date.now().toISOString(),
-      'updated_at', Date.now().toISOString(),
+      'created_at', new Date().toISOString(),
+      'updated_at', new Date().toISOString(),
       'url', req.body.imageURL
     ], (err, redisRes) => {
       if (err) throw err;

--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -21,8 +21,8 @@ async function predict(req, res) {
       'original_name', req.body.imageName,
       'postprocess_function', req.body.postprocess_function,
       'status', 'new',
-      'timestamp_last_status_update', Date.now(),
-      'timestamp_upload', Date.now(),
+      'created_at', Date.now(),
+      'updated_at', Date.now(),
       'url', req.body.imageURL
     ], (err, redisRes) => {
       if (err) throw err;

--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -21,8 +21,8 @@ async function predict(req, res) {
       'original_name', req.body.imageName,
       'postprocess_function', req.body.postprocess_function,
       'status', 'new',
-      'created_at', Date.now(),
-      'updated_at', Date.now(),
+      'created_at', Date.now().toISOString(),
+      'updated_at', Date.now().toISOString(),
       'url', req.body.imageURL
     ], (err, redisRes) => {
       if (err) throw err;

--- a/server/controllers/train.controller.js
+++ b/server/controllers/train.controller.js
@@ -5,7 +5,7 @@ import logger from '../config/winston';
 
 async function train(req, res) {
   const redisKey = `train_${req.body.imageName}_${Date.now()}`;
-  const queueName = 'train';
+  // const queueName = 'train';
   let prefix = config.uploadDirectory;
   if (prefix[prefix.length - 1] === '/') {
     prefix = prefix.slice(0, prefix.length - 1);
@@ -31,11 +31,11 @@ async function train(req, res) {
     ], (err, redisRes) => {
       if (err) throw err;
       logger.info(`redis.hmset response: ${redisRes}`);
-      client.lpush(queueName, redisKey, (err, pushRes) => {
-        if (err) throw err;
-        logger.info(`redis.lpush response: ${pushRes}`);
-        return res.status(httpStatus.OK).send({ hash: redisKey });
-      });
+      // client.lpush(queueName, redisKey, (err, pushRes) => {
+      //   if (err) throw err;
+      //   logger.info(`redis.lpush response: ${pushRes}`);
+      return res.status(httpStatus.OK).send({ hash: redisKey });
+      // });
     });
   } catch (err) {
     logger.error(`Encountered Error in /train: ${err}`);

--- a/server/controllers/train.controller.js
+++ b/server/controllers/train.controller.js
@@ -23,8 +23,8 @@ async function train(req, res) {
       'optimizer', req.body.optimizer,
       'skips', req.body.skips,
       'status', 'new',
-      'updated_at', Date.now().toISOString(),
-      'created_at', Date.now().toISOString(),
+      'updated_at', new Date().toISOString(),
+      'created_at', new Date().toISOString(),
       'training_type', req.body.trainingType,
       'transform', req.body.transform,
       'url', req.body.imageURL

--- a/server/controllers/train.controller.js
+++ b/server/controllers/train.controller.js
@@ -23,8 +23,8 @@ async function train(req, res) {
       'optimizer', req.body.optimizer,
       'skips', req.body.skips,
       'status', 'new',
-      'updated_at', Date.now(),
-      'created_at', Date.now(),
+      'updated_at', Date.now().toISOString(),
+      'created_at', Date.now().toISOString(),
       'training_type', req.body.trainingType,
       'transform', req.body.transform,
       'url', req.body.imageURL

--- a/server/controllers/train.controller.js
+++ b/server/controllers/train.controller.js
@@ -5,6 +5,7 @@ import logger from '../config/winston';
 
 async function train(req, res) {
   const redisKey = `train_${req.body.imageName}_${Date.now()}`;
+  const queueName = 'train';
   let prefix = config.uploadDirectory;
   if (prefix[prefix.length - 1] === '/') {
     prefix = prefix.slice(0, prefix.length - 1);
@@ -30,7 +31,11 @@ async function train(req, res) {
     ], (err, redisRes) => {
       if (err) throw err;
       logger.info(`redis.hmset response: ${redisRes}`);
-      return res.status(httpStatus.OK).send({ hash: redisKey });
+      client.lpush(queueName, redisKey, (err, pushRes) => {
+        if (err) throw err;
+        logger.info(`redis.lpush response: ${pushRes}`);
+        return res.status(httpStatus.OK).send({ hash: redisKey });
+      });
     });
   } catch (err) {
     logger.error(`Encountered Error in /train: ${err}`);

--- a/server/controllers/train.controller.js
+++ b/server/controllers/train.controller.js
@@ -23,8 +23,8 @@ async function train(req, res) {
       'optimizer', req.body.optimizer,
       'skips', req.body.skips,
       'status', 'new',
-      'timestamp_last_status_update', Date.now(),
-      'timestamp_upload', Date.now(),
+      'updated_at', Date.now(),
+      'created_at', Date.now(),
       'training_type', req.body.trainingType,
       'transform', req.body.transform,
       'url', req.body.imageURL


### PR DESCRIPTION
When a new key is added to redis, also add a key to the work queue.

Parse new `created_at` and `updated_at` timestamps, and process as strings. Save them as ISOFormat strings.