### PR TITLE
Batch API for creating and monitoring multiple jobs simultaneously

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "fg-loadcss": "2.0.1",
     "helmet": "3.13.0",
     "http-status": "1.2.0",
+    "ioredis": "^4.9.0",
     "joi": "13.6.0",
     "morgan": "1.9.1",
     "multer": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "fg-loadcss": "2.0.1",
     "helmet": "3.13.0",
     "http-status": "1.2.0",
-    "ioredis": "^4.9.0",
     "joi": "13.6.0",
     "morgan": "1.9.1",
     "multer": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-router-dom": "4.3.1",
     "react-tabs": "2.2.2",
     "redis": "2.8.0",
+    "uuid": "^3.3.2",
     "winston": "3.1.0"
   },
   "devDependencies": {

--- a/server/config/redis.js
+++ b/server/config/redis.js
@@ -1,4 +1,3 @@
-// import Redis from 'ioredis';
 import redis from 'redis';
 import config from './config';
 import logger from './winston';

--- a/server/config/redis.js
+++ b/server/config/redis.js
@@ -1,15 +1,17 @@
-import Redis from 'ioredis';
+// import Redis from 'ioredis';
+import redis from 'redis';
 import config from './config';
 import logger from './winston';
 
-const client = Redis.createClient({
-  host: config.redis.host,
-  port: config.redis.port,
-});
+function createClient() {
+  const client = redis.createClient(config.redis);
 
-// handle any errors whilst connecting to Redis.
-client.on('error', (err) => {
-  logger.error(`Error while communicating with Redis: ${err}`);
-});
+  // handle any errors whilst connecting to Redis.
+  client.on('error', (err) => {
+    logger.error(`Error while communicating with Redis: ${err}`);
+  });
 
-export default client;
+  return client;
+}
+
+export default createClient;

--- a/server/config/redis.js
+++ b/server/config/redis.js
@@ -13,4 +13,6 @@ function createClient() {
   return client;
 }
 
-export default createClient;
+const client = createClient();
+
+export default client;

--- a/server/config/redis.js
+++ b/server/config/redis.js
@@ -1,8 +1,11 @@
-import redis from 'redis';
+import Redis from 'ioredis';
 import config from './config';
 import logger from './winston';
 
-const client = redis.createClient(config.redis);
+const client = Redis.createClient({
+  host: config.redis.host,
+  port: config.redis.port,
+});
 
 // handle any errors whilst connecting to Redis.
 client.on('error', (err) => {

--- a/server/controllers/model.controller.js
+++ b/server/controllers/model.controller.js
@@ -42,7 +42,7 @@ async function getAwsKeys(params, keys) {
     await getAwsKeys(newParams, keys); // RECURSIVE CALL
   }
 }
-  
+
 async function getAwsModels(req, res) {
   let modelPrefix = config.model.prefix;
   if (modelPrefix[modelPrefix.length - 1] !== '/') {
@@ -66,7 +66,7 @@ async function getAwsModels(req, res) {
         MaxKeys: 2147483647, // Maximum allowed by S3 API
       };
     });
-  
+
     let allModels = [];
     await Promise.all(arrayOfParams.map(param => getAwsKeys(param, allModels)));
     let cleanModels = getModelObject(allModels);
@@ -97,7 +97,7 @@ async function getGcpModels(req, res) {
     let allModels = [];
     let models = [];
     await getGcpKeys(bucket, config.model.prefix, models);
-    await Promise.all(models.map(m => getGcpKeys(bucket, m, allModels)));  
+    await Promise.all(models.map(m => getGcpKeys(bucket, m, allModels)));
     let cleanModels = getModelObject(allModels);
     logger.info(`Found Models: ${JSON.stringify(cleanModels, null, 4)}`);
     res.status(httpStatus.OK).send({ models: cleanModels });

--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -114,7 +114,7 @@ async function batchPredict(req, res) {
   }
 
   const client = createClient();
-  let hashes = [];
+  const hashes = [];
 
   try {
     await Promise.all(req.body.jobs.map(j => batchAddKeys(client, j, hashes)));

--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -66,7 +66,7 @@ async function pushRedisKey(client, redisKey) {
 }
 
 async function batchAddKeys(client, job, arr) {
-  let redisKey = `predict_${job.imageName}_${uuidv4()}`;
+  let redisKey = `predict:${job.imageName}:${uuidv4()}`;
   await addRedisKey(client, redisKey, job);
   Array.prototype.push.apply(arr, [redisKey]);
 }
@@ -77,7 +77,7 @@ async function predict(req, res) {
     return res.sendStatus(httpStatus.BAD_REQUEST);
   }
 
-  const redisKey = `predict_${req.body.imageName}_${uuidv4()}`;
+  const redisKey = `predict:${req.body.imageName}:${uuidv4()}`;
 
   try {
     await addRedisKey(client, redisKey, req.body);

--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -1,4 +1,5 @@
 import httpStatus from 'http-status';
+import uuidv4 from 'uuid/v4';
 import { promisify } from 'util';
 import createClient from '../config/redis';
 import config from '../config/config';
@@ -65,7 +66,7 @@ async function pushRedisKey(client, redisKey) {
 }
 
 async function batchAddKeys(client, job, arr) {
-  let redisKey = `predict_${job.imageName}_${Date.now()}`;
+  let redisKey = `predict_${job.imageName}_${uuidv4()}`;
   await addRedisKey(client, redisKey, job);
   Array.prototype.push.apply(arr, [redisKey]);
 }
@@ -77,7 +78,7 @@ async function predict(req, res) {
   }
 
   const client = createClient();
-  const redisKey = `predict_${req.body.imageName}_${Date.now()}`;
+  const redisKey = `predict_${req.body.imageName}_${uuidv4()}`;
 
   try {
     await addRedisKey(client, redisKey, req.body);

--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -1,7 +1,7 @@
 import httpStatus from 'http-status';
 import uuidv4 from 'uuid/v4';
 import { promisify } from 'util';
-import createClient from '../config/redis';
+import client from '../config/redis';
 import config from '../config/config';
 import logger from '../config/winston';
 
@@ -77,7 +77,6 @@ async function predict(req, res) {
     return res.sendStatus(httpStatus.BAD_REQUEST);
   }
 
-  const client = createClient();
   const redisKey = `predict_${req.body.imageName}_${uuidv4()}`;
 
   try {
@@ -114,7 +113,6 @@ async function batchPredict(req, res) {
     }
   }
 
-  const client = createClient();
   const hashes = [];
 
   try {

--- a/server/controllers/redis.controller.js
+++ b/server/controllers/redis.controller.js
@@ -1,19 +1,48 @@
 import httpStatus from 'http-status';
+import { promisify } from 'util';
 import createClient from '../config/redis';
 import logger from '../config/winston';
 
+// helper functions
+async function getRedisValue(client, key, field) {
+  const hgetAsync = promisify(client.hget).bind(client);
+  const value = await hgetAsync(key, field);
+  logger.debug(`Hash ${key} has ${field} = ${value}`);
+  return value;
+}
+
+async function getRedisValues(client, key, field, arr) {
+  // get the same field from many keys
+  const value = await getRedisValue(client, key, field);
+  Array.prototype.push.apply(arr, [value]);
+}
+
+// route handlers
 async function getKey(req, res) {
   const client = createClient();
   const redisHash = req.body.hash;
   const redisKey = req.body.key;
-  client.hget(redisHash, redisKey, (err, value) => {
-    if (err) {
-      logger.error(`Could not get hash ${redisHash} key ${redisKey} values: ${err}`);
-      return res.sendStatus(httpStatus.INTERNAL_SERVER_ERROR);
-    }
-    logger.debug(`Hash ${redisHash} has ${redisKey} = ${value}`);
+  try {
+    const value = await getRedisValue(client, redisHash, redisKey);
     return res.status(httpStatus.OK).send({ value: value });
-  });
+  } catch (err) {
+    logger.error(`Could not get hash ${redisHash} key ${redisKey} values: ${err}`);
+    return res.sendStatus(httpStatus.INTERNAL_SERVER_ERROR);
+  }
+}
+
+async function getJobStatus(req, res) {
+  const client = createClient();
+  const redisHash = req.body.hash;
+  try {
+    const value = await getRedisValue(client, redisHash, 'status');
+    return res.status(httpStatus.OK).send({ status: value });
+  } catch (err) {
+    logger.error(`Could not get hash ${redisHash} status: ${err}`);
+    return res.sendStatus(httpStatus.INTERNAL_SERVER_ERROR);
+  }
+}
+
 }
 
 async function expireHash(req, res) {
@@ -37,5 +66,6 @@ async function expireHash(req, res) {
 
 export default {
   getKey,
-  expireHash
+  expireHash,
+  getJobStatus,
 };

--- a/server/controllers/redis.controller.js
+++ b/server/controllers/redis.controller.js
@@ -1,6 +1,6 @@
 import httpStatus from 'http-status';
 import { promisify } from 'util';
-import createClient from '../config/redis';
+import client from '../config/redis';
 import logger from '../config/winston';
 
 // helper functions
@@ -19,7 +19,6 @@ async function getRedisValues(client, key, field, arr) {
 
 // route handlers
 async function getKey(req, res) {
-  const client = createClient();
   const redisHash = req.body.hash;
   const redisKey = req.body.key;
   try {
@@ -32,7 +31,6 @@ async function getKey(req, res) {
 }
 
 async function getJobStatus(req, res) {
-  const client = createClient();
   const redisHash = req.body.hash;
   try {
     const value = await getRedisValue(client, redisHash, 'status');
@@ -44,7 +42,6 @@ async function getJobStatus(req, res) {
 }
 
 async function batchGetKeys(req, res) {
-  const client = createClient();
   const hashes = req.body.hashes;
   const key = req.body.key;
   const values = [];
@@ -58,7 +55,6 @@ async function batchGetKeys(req, res) {
 }
 
 async function batchGetJobStatus(req, res) {
-  const client = createClient();
   const hashes = req.body.hashes;
   const statuses = [];
 
@@ -72,7 +68,6 @@ async function batchGetJobStatus(req, res) {
 }
 
 async function expireHash(req, res) {
-  const client = createClient();
   const redisHash = req.body.hash;
   const expireTime = req.body.expireIn || 3600;
 

--- a/server/controllers/redis.controller.js
+++ b/server/controllers/redis.controller.js
@@ -43,6 +43,21 @@ async function getJobStatus(req, res) {
   }
 }
 
+async function batchGetJobStatus(req, res) {
+  const client = createClient();
+  const redisHashes = req.body.hashes;
+
+  const statuses = [];
+
+  try {
+    await Promise.all(req.body.hashes.map((h) => {
+      getRedisValues(client, h, 'status', statuses)
+    }));
+    return res.status(httpStatus.OK).send({ statuses: statuses });
+  } catch (err) {
+    logger.error(`Error waiting for status checks for ${redisHashes}: ${err}`);
+    return res.sendStatus(httpStatus.INTERNAL_SERVER_ERROR);
+  }
 }
 
 async function expireHash(req, res) {
@@ -68,4 +83,5 @@ export default {
   getKey,
   expireHash,
   getJobStatus,
+  batchGetJobStatus
 };

--- a/server/controllers/redis.controller.js
+++ b/server/controllers/redis.controller.js
@@ -1,8 +1,9 @@
 import httpStatus from 'http-status';
-import client from '../config/redis';
+import createClient from '../config/redis';
 import logger from '../config/winston';
 
 async function getKey(req, res) {
+  const client = createClient();
   const redisHash = req.body.hash;
   const redisKey = req.body.key;
   client.hget(redisHash, redisKey, (err, value) => {
@@ -16,6 +17,7 @@ async function getKey(req, res) {
 }
 
 async function expireHash(req, res) {
+  const client = createClient();
   const redisHash = req.body.hash;
   const expireTime = req.body.expireIn || 3600;
 

--- a/server/controllers/train.controller.js
+++ b/server/controllers/train.controller.js
@@ -1,11 +1,10 @@
 import httpStatus from 'http-status';
 import uuidv4 from 'uuid/v4';
 import config from '../config/config';
-import createClient from '../config/redis';
+import client from '../config/redis';
 import logger from '../config/winston';
 
 async function train(req, res) {
-  const client = createClient();
   const redisKey = `train_${req.body.imageName}_${uuidv4()}`;
   // const queueName = 'train';
   let prefix = config.uploadDirectory;

--- a/server/controllers/train.controller.js
+++ b/server/controllers/train.controller.js
@@ -1,9 +1,10 @@
 import httpStatus from 'http-status';
 import config from '../config/config';
-import client from '../config/redis';
+import createClient from '../config/redis';
 import logger from '../config/winston';
 
 async function train(req, res) {
+  const client = createClient();
   const redisKey = `train_${req.body.imageName}_${Date.now()}`;
   // const queueName = 'train';
   let prefix = config.uploadDirectory;

--- a/server/controllers/train.controller.js
+++ b/server/controllers/train.controller.js
@@ -5,7 +5,7 @@ import client from '../config/redis';
 import logger from '../config/winston';
 
 async function train(req, res) {
-  const redisKey = `train_${req.body.imageName}_${uuidv4()}`;
+  const redisKey = `train:${req.body.imageName}_${uuidv4()}`;
   // const queueName = 'train';
   let prefix = config.uploadDirectory;
   if (prefix[prefix.length - 1] === '/') {

--- a/server/controllers/train.controller.js
+++ b/server/controllers/train.controller.js
@@ -1,11 +1,12 @@
 import httpStatus from 'http-status';
+import uuidv4 from 'uuid/v4';
 import config from '../config/config';
 import createClient from '../config/redis';
 import logger from '../config/winston';
 
 async function train(req, res) {
   const client = createClient();
-  const redisKey = `train_${req.body.imageName}_${Date.now()}`;
+  const redisKey = `train_${req.body.imageName}_${uuidv4()}`;
   // const queueName = 'train';
   let prefix = config.uploadDirectory;
   if (prefix[prefix.length - 1] === '/') {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -31,6 +31,9 @@ router.route('/redis')
 router.route('/status')
   .post(controllers.redisController.getJobStatus);
 
+router.route('/batch/status')
+  .post(controllers.redisController.batchGetJobStatus);
+
 router.route('/redis/expire')
   .post(controllers.redisController.expireHash);
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -28,6 +28,9 @@ router.route('/models')
 router.route('/redis')
   .post(controllers.redisController.getKey);
 
+router.route('/batch/redis')
+  .post(controllers.redisController.batchGetKeys);
+
 router.route('/status')
   .post(controllers.redisController.getJobStatus);
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -16,6 +16,9 @@ router.route('/upload')
 router.route('/predict')
   .post(controllers.predictController.predict);
 
+router.route('/batch/predict')
+  .post(controllers.predictController.batchPredict);
+
 router.route('/train')
   .post(controllers.trainController.train);
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -28,6 +28,9 @@ router.route('/models')
 router.route('/redis')
   .post(controllers.redisController.getKey);
 
+router.route('/status')
+  .post(controllers.redisController.getJobStatus);
+
 router.route('/redis/expire')
   .post(controllers.redisController.expireHash);
 

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -46,8 +46,9 @@ class Predict extends React.Component {
       model: '',
       version: '',
       fileName: '',
-      imageURL: '',
+      imageUrl: '',
       postprocess: '',
+      preprocess: '',
       cuts: 0,
       downloadURL: null,
       submitted: false,
@@ -171,10 +172,11 @@ class Predict extends React.Component {
       data: {
         'imageName': this.state.fileName,
         'uploadedName': this.state.uploadedFileName,
-        'imageURL': this.state.imageURL,
-        'model_name': this.state.model,
-        'model_version': this.state.version,
-        'postprocess_function': this.state.postprocess,
+        'imageUrl': this.state.imageUrl,
+        'modelName': this.state.model,
+        'modelVersion': this.state.version,
+        'postprocessFunction': this.state.postprocess,
+        'preprocessFunction': this.state.preprocess,
         'cuts': this.state.cuts
       }
     }).then((response) => {
@@ -188,7 +190,7 @@ class Predict extends React.Component {
   canBeSubmitted() {
     return (
       this.state.fileName.length > 0 &&
-      this.state.imageURL.length > 0 &&
+      this.state.imageUrl.length > 0 &&
       this.state.model.length > 0 &&
       this.state.version.length > 0
     );
@@ -321,7 +323,7 @@ class Predict extends React.Component {
                   this.setState({
                     uploadedFileName: uploadedName,
                     fileName: fileName,
-                    imageURL: url }) } />
+                    imageUrl: url }) } />
             </Grid>
 
             { this.state.showError ?

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -128,17 +128,14 @@ class Predict extends React.Component {
     this.statusCheck = setInterval(() => {
       axios({
         method: 'post',
-        url: '/api/redis',
-        data: {
-          'hash': redisHash,
-          'key': 'status'
-        }
+        url: '/api/status',
+        data: { 'hash': redisHash }
       }).then((response) => {
-        if (response.data.value === 'failed') {
+        if (response.data.status === 'failed') {
           clearInterval(this.statusCheck);
           this.getErrorReason(redisHash);
           this.expireRedisHash(redisHash, 3600);
-        } else if (response.data.value === 'done') {
+        } else if (response.data.status === 'done') {
           clearInterval(this.statusCheck);
           axios({
             method: 'post',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1945,11 +1945,6 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-cluster-key-slot@^1.0.6:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.12.tgz#d5deff2a520717bc98313979b687309b2d368e29"
-  integrity sha512-21O0kGmvED5OJ7ZTdqQ5lQQ+sjuez33R+d35jZKLwqUb5mqcPHUsxOSzj61+LHVtxGZd1kShbQM3MjB/gBJkVg==
-
 coa@~1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/coa/-/coa-1.0.4.tgz#a9ef153660d6a86a8bdec0289a5c684d217432fd"
@@ -2611,11 +2606,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
-denque@^1.1.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
-  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
 
 depd@1.1.1:
   version "1.1.1"
@@ -3450,11 +3440,6 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
-
-flexbuffer@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/flexbuffer/-/flexbuffer-0.0.6.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
-  integrity sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA=
 
 flush-write-stream@^1.0.0:
   version "1.1.0"
@@ -4309,22 +4294,6 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-ioredis@^4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.9.0.tgz#0c52de498363309ebd48b5f6695d9d432b0f6669"
-  integrity sha512-YzfCLsN++Ct43QqGK9CWxaEK6OUvJ7rnENieAPNw3DVp/oF2uBrP2NJChbhO74Ng3LWA+i5zdIEUsZYr6dKDIQ==
-  dependencies:
-    cluster-key-slot "^1.0.6"
-    debug "^3.1.0"
-    denque "^1.1.0"
-    flexbuffer "0.0.6"
-    lodash.defaults "^4.2.0"
-    lodash.flatten "^4.4.0"
-    redis-commands "1.4.0"
-    redis-errors "^1.2.0"
-    redis-parser "^3.0.0"
-    standard-as-callback "^2.0.1"
-
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
@@ -5009,16 +4978,6 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
-
-lodash.defaults@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
-  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
-
-lodash.flatten@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -6776,27 +6735,15 @@ recompose@^0.29.0:
     react-lifecycles-compat "^3.0.2"
     symbol-observable "^1.0.4"
 
-redis-commands@1.4.0, redis-commands@^1.2.0:
+redis-commands@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.4.0.tgz#52f9cf99153efcce56a8f86af986bd04e988602f"
   integrity sha512-cu8EF+MtkwI4DLIT0x9P8qNTLFhQD4jLfxLR0cCNkeGzs87FN6879JOJwNQR/1zD7aSYNbU0hgsV9zGY71Itvw==
-
-redis-errors@^1.0.0, redis-errors@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
-  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
 
 redis-parser@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
   integrity sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=
-
-redis-parser@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
-  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
-  dependencies:
-    redis-errors "^1.0.0"
 
 redis@2.8.0:
   version "2.8.0"
@@ -7531,11 +7478,6 @@ stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
-
-standard-as-callback@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.0.1.tgz#ed8bb25648e15831759b6023bdb87e6b60b38126"
-  integrity sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==
 
 static-extend@^0.1.1:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,9 +1092,9 @@ acorn@^5.0.0, acorn@^5.6.2:
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
 acorn@^6.0.2:
-  version "6.0.7"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.7.tgz#490180ce18337270232d9488a44be83d9afb7fd3"
-  integrity sha512-HNJNgE60C9eOTgn974Tlp3dpLZdUr+SoxxDwPaY9J/kDNOLQTkaDgwBUXAF4SSsrAwD9RpdxuHK/EbuF+W9Ahw==
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
 agent-base@^4.1.0:
   version "4.2.1"
@@ -1108,12 +1108,27 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
-ajv-keywords@^3.0.0, ajv-keywords@^3.1.0:
+ajv-keywords@^3.0.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
+  integrity sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
+
+ajv-keywords@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.3.0.tgz#cb6499da9b83177af8bc1732b2f0a1a1a3aacf8c"
   integrity sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g==
 
-ajv@^6.0.1, ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.5:
+ajv@^6.0.1, ajv@^6.5.3:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.1.0, ajv@^6.5.5:
   version "6.8.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.8.1.tgz#0890b93742985ebf8973cd365c5b23920ce3cb20"
   integrity sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==
@@ -1160,10 +1175,10 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
-  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -1930,6 +1945,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
+cluster-key-slot@^1.0.6:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.12.tgz#d5deff2a520717bc98313979b687309b2d368e29"
+  integrity sha512-21O0kGmvED5OJ7ZTdqQ5lQQ+sjuez33R+d35jZKLwqUb5mqcPHUsxOSzj61+LHVtxGZd1kShbQM3MjB/gBJkVg==
+
 coa@~1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/coa/-/coa-1.0.4.tgz#a9ef153660d6a86a8bdec0289a5c684d217432fd"
@@ -2592,6 +2612,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+denque@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
+  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
+
 depd@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
@@ -2954,9 +2979,9 @@ eslint-scope@^3.7.1:
     estraverse "^4.1.1"
 
 eslint-scope@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
-  integrity sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
+  integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
@@ -3426,6 +3451,11 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
+flexbuffer@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/flexbuffer/-/flexbuffer-0.0.6.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
+  integrity sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA=
+
 flush-write-stream@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.0.tgz#2e89a8bd5eee42f8ec97e43aae81e3d5099c2ddc"
@@ -3648,10 +3678,15 @@ global@^4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^11.1.0, globals@^11.7.0:
+globals@^11.1.0:
   version "11.10.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
   integrity sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==
+
+globals@^11.7.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globby@^6.1.0:
   version "6.1.0"
@@ -4206,7 +4241,7 @@ ini@^1.3.4, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-inquirer@^6.0.0, inquirer@^6.1.0:
+inquirer@^6.0.0:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
   integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
@@ -4223,6 +4258,25 @@ inquirer@^6.0.0, inquirer@^6.1.0:
     rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.0.0"
+    through "^2.3.6"
+
+inquirer@^6.1.0:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+  integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.11"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
     through "^2.3.6"
 
 internal-ip@^3.0.1:
@@ -4254,6 +4308,22 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
+ioredis@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.9.0.tgz#0c52de498363309ebd48b5f6695d9d432b0f6669"
+  integrity sha512-YzfCLsN++Ct43QqGK9CWxaEK6OUvJ7rnENieAPNw3DVp/oF2uBrP2NJChbhO74Ng3LWA+i5zdIEUsZYr6dKDIQ==
+  dependencies:
+    cluster-key-slot "^1.0.6"
+    debug "^3.1.0"
+    denque "^1.1.0"
+    flexbuffer "0.0.6"
+    lodash.defaults "^4.2.0"
+    lodash.flatten "^4.4.0"
+    redis-commands "1.4.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.0.1"
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -4627,9 +4697,9 @@ js-tokens@^3.0.2:
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
 js-yaml@^3.12.0:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
-  integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -4939,6 +5009,16 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -6696,15 +6776,27 @@ recompose@^0.29.0:
     react-lifecycles-compat "^3.0.2"
     symbol-observable "^1.0.4"
 
-redis-commands@^1.2.0:
+redis-commands@1.4.0, redis-commands@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.4.0.tgz#52f9cf99153efcce56a8f86af986bd04e988602f"
   integrity sha512-cu8EF+MtkwI4DLIT0x9P8qNTLFhQD4jLfxLR0cCNkeGzs87FN6879JOJwNQR/1zD7aSYNbU0hgsV9zGY71Itvw==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
 
 redis-parser@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
   integrity sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
 
 redis@2.8.0:
   version "2.8.0"
@@ -7019,9 +7111,9 @@ rxjs@6.2.2:
     tslib "^1.9.0"
 
 rxjs@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
-  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.1.tgz#f7a005a9386361921b8524f38f54cbf80e5d08f4"
+  integrity sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==
   dependencies:
     tslib "^1.9.0"
 
@@ -7093,10 +7185,15 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@^5.5.0, semver@^5.5.1:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 send@0.16.2:
   version "0.16.2"
@@ -7435,6 +7532,11 @@ stack-trace@0.0.x:
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
+standard-as-callback@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.0.1.tgz#ed8bb25648e15831759b6023bdb87e6b60b38126"
+  integrity sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -7552,12 +7654,12 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
-  integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
+strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
-    ansi-regex "^4.0.0"
+    ansi-regex "^4.1.0"
 
 strip-eof@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Created a new batch API that handles lists of objects rather than a single object for both the `/predict` and `/redis/status` endpoints.

Additionally, created async Redis client calls for calling many requests simultaneously.

Finally, updated formatting of redis keys (using ":"s as separators rather than "_") and using the `uuid` package for random string rather than `Date.now()` for guaranteed uniqueness.