### PR TITLE
update the redis client to use redis-ha to prevent READONLY errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-router": "4.3.1",
     "react-router-dom": "4.3.1",
     "react-tabs": "2.2.2",
-    "redis": "2.8.0",
+    "redis-ha": "^0.1.0",
     "uuid": "^3.3.2",
     "winston": "3.1.0"
   },

--- a/server/config/redis.js
+++ b/server/config/redis.js
@@ -1,4 +1,4 @@
-import redis from 'redis';
+import redis from 'redis-ha';
 import config from './config';
 import logger from './winston';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3122,7 +3122,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@^3.0.1, extend@^3.0.2, extend@~3.0.2:
+extend@>=1.1.x, extend@^3.0.0, extend@^3.0.1, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -6320,12 +6320,20 @@ redis-commands@^1.2.0:
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.5.0.tgz#80d2e20698fe688f227127ff9e5164a7dd17e785"
   integrity sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==
 
+redis-ha@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/redis-ha/-/redis-ha-0.1.0.tgz#80f976acb1591c24a378a590711b4e966f683407"
+  integrity sha1-gPl2rLFZHCSjeKWQcRtOlm9oNAc=
+  dependencies:
+    extend ">=1.1.x"
+    redis ">=0.8.x"
+
 redis-parser@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
   integrity sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=
 
-redis@2.8.0:
+redis@>=0.8.x:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
   integrity sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==


### PR DESCRIPTION
`redis-ha` package prevents the redis client from only connecting with redis READONLY slaves.