### PR TITLE
Use REDIS_SENTINEL to determine which type of redis client to create.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fg-loadcss": "2.0.1",
     "helmet": "3.13.0",
     "http-status": "1.2.0",
-    "ioredis": "^4.11.1",
+    "ioredis": "^4.14.0",
     "joi": "13.6.0",
     "morgan": "1.9.1",
     "multer": "1.3.1",

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -39,7 +39,8 @@ const envVarsSchema = Joi.object({
   REDIS_HOST: Joi.string().required()
     .description('Redis DB host url'),
   REDIS_PORT: Joi.number()
-    .default(6379)
+    .default(6379),
+  REDIS_SENTINEL: Joi.boolean().valid(true)
 }).unknown().required();
 
 const { error, value: envVars } = Joi.validate(process.env, envVarsSchema);
@@ -65,7 +66,8 @@ const config = {
   },
   redis: {
     host: envVars.REDIS_HOST,
-    port: envVars.REDIS_PORT
+    port: envVars.REDIS_PORT,
+    sentinelEnabled: envVars.REDIS_SENTINEL,
   },
   model: {
     prefix: envVars.MODEL_PREFIX

--- a/yarn.lock
+++ b/yarn.lock
@@ -1998,10 +1998,10 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
-cluster-key-slot@^1.0.6:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.12.tgz#d5deff2a520717bc98313979b687309b2d368e29"
-  integrity sha512-21O0kGmvED5OJ7ZTdqQ5lQQ+sjuez33R+d35jZKLwqUb5mqcPHUsxOSzj61+LHVtxGZd1kShbQM3MjB/gBJkVg==
+cluster-key-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
+  integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -4344,12 +4344,12 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-ioredis@^4.11.1:
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.11.1.tgz#cf14cf923b10a772d7e1eafed89f707e05760f48"
-  integrity sha512-Qnp7ecb3WeaL7ojeSlb0UBRXmsRMMFcjM+PaAcap8FLLf1NznRD6x96/PS2DEqoRfdM9WVffAjIIYuUp+q3zEw==
+ioredis@^4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.14.0.tgz#d0e83b1d308ca1ba6e849798bfe91583b560eaac"
+  integrity sha512-vGzyW9QTdGMjaAPUhMj48Z31mIO5qJLzkbsE5dg+orNi7L5Ph035htmkBZNDTDdDk7kp7e9UJUr+alhRuaWp8g==
   dependencies:
-    cluster-key-slot "^1.0.6"
+    cluster-key-slot "^1.1.0"
     debug "^4.1.1"
     denque "^1.1.0"
     lodash.defaults "^4.2.0"


### PR DESCRIPTION
`REDIS_SENTINEL` is parsed from the environment to pass the `config.redis` credentials to `ioredis` as a sentinel or as a regular client.  This enables backwards compatibility with previous versions using `node-redis`, but `REDIS_SENTINEL` will be required in the environment in order to use sentinel mode.