### PR TITLE
All job types are defined in the environment and exposed with a backend route.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,7 @@ DeepCell graphical user interface built using React, Babel, Webpack. Run with `n
 
 ## Adding new Job Types
 
-You can support new job types by making small changes to two files:
-
-* `/src/Predict/Predict.js` - Add a new element to the drop down (e.g. `<MenuItem value={'queueName'}>New Queue Name</MenuItem>`)
-* `/server/controllers/predict.controller.js` - Add a new conditional statement to the `predict` function for your new queue name.
-
-With these two changes, the frontend will add and monitor new Redis queues. Please see [this branch](https://github.com/vanvalenlab/kiosk-frontend/tree/mibi) for example implementation of two custom pipelines.
+The job types are defined as an environment variable `JOB_TYPES`, which evaluates to `"segmentation,tracking"` by default. This can easily be extended by overriding the list with custom job type values, by just adding to this string, for example, `"segmentation,tracking,spot detection"`. These values are parsed into a list and populated into the drop-down with the route `/jobtypes`. Each job type value is also the exact value of the Redis queue used by the corresponding consumer (e.g. `"segmentation"` is both the job type, and the queue used for the `segmentation-consumer`).
 
 ## Front End React Hierarchy Diagram
 ![Alt text](./docs/kiosk-frontend-react.png)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ DeepCell graphical user interface built using React, Babel, Webpack. Run with `n
 
 ## Adding new Job Types
 
-The job types are defined as an environment variable `JOB_TYPES`, which evaluates to `"segmentation,tracking"` by default. This can easily be extended by overriding the list with custom job type values, by just adding to this string, for example, `"segmentation,tracking,spot detection"`. These values are parsed into a list and populated into the drop-down with the route `/jobtypes`. Each job type value is also the exact value of the Redis queue used by the corresponding consumer (e.g. `"segmentation"` is both the job type, and the queue used for the `segmentation-consumer`).
+The job types are defined as an environment variable `JOB_TYPES`, which evaluates to `"segmentation,tracking"` by default. This can easily be extended by just adding to this string, for example, `"segmentation,tracking,spot detection"`. These values are parsed into a list and populated into the drop-down with the route `/jobtypes`. Each job type value is also the exact value of the Redis queue used by the corresponding consumer (e.g. `"segmentation"` is both the job type, and the queue used for the `segmentation-consumer`).
 
 ## Front End React Hierarchy Diagram
 ![Alt text](./docs/kiosk-frontend-react.png)

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -41,7 +41,9 @@ const envVarsSchema = Joi.object({
   REDIS_PORT: Joi.number()
     .default(6379),
   REDIS_SENTINEL: Joi.boolean()
-    .default(true)
+    .default(true),
+  JOB_TYPES: Joi.string().default('predict,track')
+    .description('Comma-separated list of job types (Redis queue names).')
 }).unknown().required();
 
 const envVars = Joi.attempt(process.env, envVarsSchema);
@@ -70,7 +72,8 @@ const config = {
   model: {
     prefix: envVars.MODEL_PREFIX
   },
-  uploadDirectory: envVars.UPLOAD_PREFIX
+  uploadDirectory: envVars.UPLOAD_PREFIX,
+  jobTypes: envVars.JOB_TYPES.split(','),
 };
 
 export default config;

--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -72,6 +72,10 @@ async function batchAddKeys(client, job, arr) {
 }
 
 // route handlers
+async function getJobTypes(req, res) {
+  return res.status(httpStatus.OK).send({ jobTypes: config.jobTypes });
+}
+
 async function predict(req, res) {
   if (!isValidPredictdata(req.body)) {
     return res.sendStatus(httpStatus.BAD_REQUEST);
@@ -138,6 +142,7 @@ async function batchPredict(req, res) {
 }
 
 export default {
+  getJobTypes,
   predict,
   batchPredict
 };

--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -77,15 +77,11 @@ async function predict(req, res) {
     return res.sendStatus(httpStatus.BAD_REQUEST);
   }
 
-  let queueName;
+  let queueName = req.body.jobType;
 
-  if (req.body.cellTracking === 'segmentation') {
-    queueName = 'predict';
-  } else if (req.body.cellTracking === 'tracking') {
-    queueName = 'track';
-  } else {
+  if (config.jobTypes.indexOf(queueName) == -1) {
     return res.status(httpStatus.BAD_REQUEST).send({
-      message: `Invalid Job Type: ${req.body.cellTracking}.`});
+      message: `Invalid Job Type: ${req.body.jobType}.`});
   }
 
   if (req.body.imageName.toLowerCase().endsWith('.zip')) {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -44,6 +44,6 @@ router.route('/redis/expire')
   .post(controllers.redisController.expireHash);
 
 router.route('/jobtypes')
-  .get(controllers.predictController.getJobTypes)
+  .get(controllers.predictController.getJobTypes);
 
 export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -43,4 +43,7 @@ router.route('/batch/status')
 router.route('/redis/expire')
   .post(controllers.redisController.expireHash);
 
+router.route('/jobtypes')
+  .get(controllers.predictController.getJobTypes)
+
 export default router;

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -52,6 +52,7 @@ class Predict extends React.Component {
       rescalingDisabled: 'true',
       rescaling: 1,
       setOpen: false,
+      allJobTypes: [],
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -62,6 +63,7 @@ class Predict extends React.Component {
   }
 
   componentDidMount() {
+    this.getAllJobTypes();
   }
 
   componentWillUnmount() {
@@ -163,6 +165,20 @@ class Predict extends React.Component {
     }, interval);
   }
 
+  getAllJobTypes() {
+    axios({
+      method: 'get',
+      url: '/api/jobtypes'
+    }).then((response) => {
+      !this.isCancelled && this.setState({
+        allJobTypes: response.data.jobTypes
+      });
+    }).catch(error => {
+      let errMsg = `Failed to get job types due to error: ${error}`;
+      this.showErrorMessage(errMsg);
+    });
+  }
+
   predict() {
     axios({
       method: 'post',
@@ -255,14 +271,17 @@ class Predict extends React.Component {
                           onOpen={this.handleOpen}
                           onChange={this.handleChange}
                           value={this.state.jobType}
+                          style={{textTransform: 'capitalize'}}
                           inputProps={{
                             name: 'jobType',
                             id: 'jobTypeValue',
                           }}
                         >
-                          <MenuItem value={'predict'}>Segmentation</MenuItem>
-                          <MenuItem value={'track'}>Tracking</MenuItem>
-                          {/* Add more custom queue values here! */}
+                          {this.state.allJobTypes.map(job => (
+                            <MenuItem value={job} style={{textTransform: 'capitalize'}} key={this.state.allJobTypes.indexOf(job)}>
+                              {job}
+                            </MenuItem>
+                          ))}
                         </Select>
                       </FormControl>
                     </Grid>

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -48,7 +48,7 @@ class Predict extends React.Component {
       showError: false,
       errorText: '',
       progress: 0,
-      cellTracking: 'segmentation',
+      jobType: 'predict',
       rescalingDisabled: 'true',
       rescaling: 1,
       setOpen: false,
@@ -172,7 +172,7 @@ class Predict extends React.Component {
         'imageName': this.state.fileName,
         'uploadedName': this.state.uploadedFileName,
         'imageUrl': this.state.imageUrl,
-        'cellTracking' : this.state.cellTracking,
+        'jobType' : this.state.jobType,
         'dataRescale': this.state.rescalingDisabled === 'true' ? '' : this.state.rescaling
       }
     }).then((response) => {
@@ -254,14 +254,15 @@ class Predict extends React.Component {
                           onClose={this.handleClose}
                           onOpen={this.handleOpen}
                           onChange={this.handleChange}
-                          value={this.state.cellTracking}
+                          value={this.state.jobType}
                           inputProps={{
-                            name: 'cellTracking',
-                            id: 'cellTrackingValue',
+                            name: 'jobType',
+                            id: 'jobTypeValue',
                           }}
                         >
-                          <MenuItem value={'segmentation'}>Segmentation</MenuItem>
-                          <MenuItem value={'tracking'}>Tracking</MenuItem>
+                          <MenuItem value={'predict'}>Segmentation</MenuItem>
+                          <MenuItem value={'track'}>Tracking</MenuItem>
+                          {/* Add more custom queue values here! */}
                         </Select>
                       </FormControl>
                     </Grid>

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -48,7 +48,7 @@ class Predict extends React.Component {
       showError: false,
       errorText: '',
       progress: 0,
-      jobType: 'predict',
+      jobType: '',
       rescalingDisabled: 'true',
       rescaling: 1,
       setOpen: false,

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -171,7 +171,8 @@ class Predict extends React.Component {
       url: '/api/jobtypes'
     }).then((response) => {
       !this.isCancelled && this.setState({
-        allJobTypes: response.data.jobTypes
+        allJobTypes: response.data.jobTypes,
+        jobType: response.data.jobTypes[0]
       });
     }).catch(error => {
       let errMsg = `Failed to get job types due to error: ${error}`;

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -29,19 +29,17 @@ module.exports = {
     ]
   },
   optimization: {
-    optimization: {
-      minimize: true,
-      minimizer: [
-        new TerserPlugin({
-          terserOptions: {
-            mangle: true,
-          },
-          cache: true,
-          parallel: true,
-          extractComments: false,
-        }),
-      ],
-    },
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          mangle: true,
+        },
+        cache: true,
+        parallel: true,
+        extractComments: false,
+      }),
+    ],
   },
   resolve: { extensions: ['*', '.js', '.jsx'] },
   output: {


### PR DESCRIPTION
This PR enables the React frontend to be isolated from the defined job types, and enables extensions to the list of job types easily with the environment variable `QUEUES`.  This should be a comma-separated string, such as "segmentation,tracking".  This is then split into a list inside the config object, and exposed via the backend route `/jobtypes`.  The frontend queries this API to populate the drop-down, and capitalizes it for display purposes.