### PR TITLE
Add "dataLabel" as optional parameter for predict API

### DIFF
--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -35,6 +35,7 @@ async function addRedisKey(client, redisKey, data) {
       'cuts', data.cuts || '0', // to split up very large images
       'url', data.imageUrl || '', // unused?
       'scale', data.dataRescale,
+      'label', data.dataLabel || '',
       'status', 'new',
       'created_at', now,
       'updated_at', now,

--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -34,7 +34,7 @@ async function addRedisKey(client, redisKey, data) {
       'preprocess_function', data.preprocessFunction || '',
       'cuts', data.cuts || '0', // to split up very large images
       'url', data.imageUrl || '', // unused?
-      'scale', data.dataRescale,
+      'scale', data.dataRescale || '',
       'label', data.dataLabel || '',
       'status', 'new',
       'created_at', now,


### PR DESCRIPTION
Enable jobs to shortcut the label detection by including the label in the creation POST request.

For example:

```bash
{
    ....,
    "dataLabel": 0,
    ....,
}
```

Additionally, this PR adds a default value for "dataScale" if it is not passed in the request.