### PR TITLE
travis_retry yarn installation during CI/CD testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - node_modules
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s
+  - travis_retry curl -o- -L https://yarnpkg.com/install.sh | bash -s
   - export PATH="$HOME/.yarn/bin:$PATH"
 install: true
 


### PR DESCRIPTION
Rarely, the `curl` command to install `yarn` during the TravisCI tests has failed, causing a failed build. `travis_retry` will automatically retry the failed command (up to 3 times). This should prevent any randomly failed installations.