### PR TITLE
Display errors for failed zip jobs and improve error formatting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "morgan": "1.9.1",
     "multer": "1.4.2",
     "multer-s3": "2.9.0",
+    "query-string": "^6.13.4",
     "react": "^16.10.1",
     "react-dom": "^16.10.1",
     "react-dropzone": "^10.1.9",

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -116,8 +116,9 @@ class Predict extends React.Component {
           this.expireRedisHash(redisHash, 3600);
           // This is only used during zip uploads.
           // Some jobs may fail while other jobs can succeed.
-          if (response.data.value[4].length > 0) {
-            const parsed = queryString.parse(response.data.value[4]);
+          const failures = response.data.value[4];
+          if (failures != null && failures.length > 0) {
+            const parsed = queryString.parse(failures);
             let errorText = 'Not all jobs completed!\n\n';
             for (const key in parsed) {
               errorText += `Job Failed: ${key}: ${parsed[key]}\n\n`;

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -118,7 +118,7 @@ class Predict extends React.Component {
           // Some jobs may fail while other jobs can succeed.
           if (response.data.value[4].length > 0) {
             const parsed = queryString.parse(response.data.value[4]);
-            let errorText = 'Not all jobs completed!\n';
+            let errorText = 'Not all jobs completed!\n\n';
             for (const key in parsed) {
               errorText += `Job Failed: ${key}: ${parsed[key]}\n\n`;
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8746,6 +8746,15 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@^6.13.4:
+  version "6.13.4"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.4.tgz#b35a9a3bd4955bce55f94feb0e819b3d0be6f66f"
+  integrity sha512-E2NPIeJoBEJGQNy3ib1k/Z/OkDBUKIo8IV2ZVwbKfoa65IS9unqWWUlLcbfU70Da0qNoxUZZA8CfKUjKLE641Q==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-browser@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/querystring-browser/-/querystring-browser-1.0.4.tgz#f2e35881840a819bc7b1bf597faf0979e6622dc6"
@@ -9913,6 +9922,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -10044,6 +10058,11 @@ streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
   integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Update the error handling to check for "reason" in addition to the "failures" field. "failures" is only populated by zip consumers, and is a URL encoded dictionary of Redis hashes to failure reasons. The `query-string` npm package was added for parsing the URL encoded "failures" string into an object, and each object is then logged as errors on the page for the user. The download button is still available for successful files. (Fixes vanvalenlab/kiosk-console#379)

Additionally, some CSS styling was added to fix the error formatting (`style={{whiteSpace: 'pre-line'}}`). This better displays the new line characters to keep the visual structure of the stack trace. (Fixes #118)

---

<img width="952" alt="New Error Format" src="https://user-images.githubusercontent.com/7930703/94492267-c9fa0b80-019e-11eb-9ac5-9a9604b0fd4c.png">
