### PR TITLE
Fix /upload test for GCP.

### DIFF
--- a/server/controllers/upload.controller.test.js
+++ b/server/controllers/upload.controller.test.js
@@ -70,7 +70,7 @@ describe('Upload Controller Tests', () => {
       const tmpobj = tmp.fileSync({postfix: '.png'});
       const request = supertest(app);
 
-      const response = request.post('/api/upload')
+      const response = await request.post('/api/upload')
         .attach('file', tmpobj.name);
 
       setTimeout(() => {


### PR DESCRIPTION
The GCP test for the /upload route using `multer` was not using the proper `await` command and would occasionally fail. This PR adds `await` and should fix the test.