### PR TITLE
Infer cloud provider from STORAGE_BUCKET protocol.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,13 @@ The `kiosk-frontend` can be configured using environmental variables in a `.env`
 | Name | Description | Default Value |
 | :--- | :--- | :--- |
 | `JOB_TYPES` | **REQUIRED**: Comma delimited list of job type names. | `"segmentation,tracking"` |
-| `GCLOUD_STORAGE_BUCKET` | **REQUIRED**: Cloud storage bucket address (e.g. `"gs://bucket-name"`). | `"invalid_default"` |
+| `STORAGE_BUCKET` | **REQUIRED**: Cloud storage bucket address (e.g. `"gs://bucket-name"`). | `""` |
 | `PORT` | Port to run the NodeJS backend server. | `8080` |
 | `REDIS_HOST` | The IP address or hostname of Redis. | `redis-master` |
 | `REDIS_PORT` | The port used to connect to Redis. | `6379` |
 | `REDIS_SENTINEL` | Whether Redis has Sentinel mode enabled. | `True` |
 | `MODEL_PREFIX` | Prefix of model directory in the cloud storage bucket. | `"/models"` |
 | `UPLOAD_PREFIX` | Prefix of upload directory in the cloud storage bucket. | `"/uploads"` |
-| `CLOUD_PROVIDER` | The cloud provider hosting the DeepCell Kiosk. | `"gke"` |
 
 ## Contribute
 

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -40,14 +40,14 @@ const envVarsSchema = Joi.object({
 
 const envVars = Joi.attempt(process.env, envVarsSchema);
 
-const parseCloudProvider = (bucketName) => {
-  const name = bucketName.toString().toLowerCase();
+const parseCloudProvider = (bucket) => {
+  const name = bucket.toString().toLowerCase();
   if (name.startsWith('s3://')) {
     return 'aws';
   } else if (name.startsWith('gs://')) {
     return 'gcp';
   }
-  throw new Error(`Invalid storage bucket ${bucketName}.`);
+  throw new Error(`Invalid storage bucket ${bucket}.`);
 };
 
 const config = {
@@ -55,7 +55,7 @@ const config = {
   cloud: parseCloudProvider(envVars.STORAGE_BUCKET),
   hostname: envVars.HOSTNAME,
   port: envVars.PORT,
-  bucket: envVars.STORAGE_BUCKET,
+  bucketName: envVars.STORAGE_BUCKET.toString().split('://')[1],
   aws: {
     accessKeyId: envVars.AWS_ACCESS_KEY_ID,
     secretAccessKey: envVars.AWS_SECRET_ACCESS_KEY,

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -11,10 +11,6 @@ const envVarsSchema = Joi.object({
     .default('development'),
   PORT: Joi.number()
     .default(8080),
-  CLOUD_PROVIDER: Joi.string()
-    .description('The cloud platform to interact with.')
-    .valid('gke', 'aws')
-    .default('aws'),
   MODEL_PREFIX: Joi.string()
     .description('S3 Folder in which models are saved')
     .default('models'),
@@ -25,14 +21,11 @@ const envVarsSchema = Joi.object({
     .default('us-east-1'),
   AWS_ACCESS_KEY_ID: Joi.string().default('invalid_value'),
   AWS_SECRET_ACCESS_KEY: Joi.string().default('invalid_value'),
-  AWS_S3_BUCKET: Joi.string()
-    .description('S3 Bucket where data is uploaded and models are saved.')
-    .default('deepcell-output'),
   GCLOUD_KEY_FILE: Joi.string().default('invalid_value'),
   GCLOUD_PROJECT_ID: Joi.string().default('invalid_value'),
-  GCLOUD_STORAGE_BUCKET: Joi.string()
-    .description('Google Cloud bucket where data is uploaded and models are saved.')
-    .default('deepcell-output'),
+  STORAGE_BUCKET: Joi.string()
+    .description('Cloud storage bucket where data is uploaded and models are saved.')
+    .default('gs://deepcell-output'),
   HOSTNAME: Joi.string()
     .description('Kubernetes pod name'),
   REDIS_HOST: Joi.string().default('localhost')
@@ -47,20 +40,29 @@ const envVarsSchema = Joi.object({
 
 const envVars = Joi.attempt(process.env, envVarsSchema);
 
+const parseCloudProvider = (bucketName) => {
+  const name = bucketName.toString().toLowerCase();
+  if (name.startsWith('s3://')) {
+    return 'aws';
+  } else if (name.startsWith('gs://')) {
+    return 'gcp';
+  }
+  throw new Error(`Invalid storage bucket ${bucketName}.`);
+};
+
 const config = {
   env: envVars.NODE_ENV,
-  cloud: envVars.CLOUD_PROVIDER,
+  cloud: parseCloudProvider(envVars.STORAGE_BUCKET),
   hostname: envVars.HOSTNAME,
   port: envVars.PORT,
+  bucket: envVars.STORAGE_BUCKET,
   aws: {
     accessKeyId: envVars.AWS_ACCESS_KEY_ID,
     secretAccessKey: envVars.AWS_SECRET_ACCESS_KEY,
-    bucketName: envVars.AWS_S3_BUCKET,
     region: envVars.AWS_REGION
   },
   gcp: {
     keyFile: envVars.GCLOUD_KEY_FILE,
-    bucketName: envVars.GCLOUD_STORAGE_BUCKET,
     projectId: envVars.GCLOUD_PROJECT_ID
   },
   redis: {

--- a/server/config/multer.js
+++ b/server/config/multer.js
@@ -23,7 +23,7 @@ const multer = Multer({
   storage: config.cloud === 'aws' ?
     multerS3({
       s3: s3,
-      bucket: config.aws.bucketName,
+      bucket: config.bucketName,
       key: (req, file, cb) => {
         cb(null, `${prefix}/${file.originalname}`);
       }

--- a/server/controllers/model.controller.js
+++ b/server/controllers/model.controller.js
@@ -50,7 +50,7 @@ async function getAwsModels(req, res) {
   }
   try {
     let params = {
-      Bucket: config.aws.bucketName,
+      Bucket: config.bucketName,
       Delimiter: '/',
       Prefix: modelPrefix,
       MaxKeys: 2147483647, // Maximum allowed by S3 API
@@ -60,7 +60,7 @@ async function getAwsModels(req, res) {
     // array of params for each listObjectsV2 call
     let arrayOfParams = models.map((prefix) => {
       return {
-        Bucket: config.aws.bucketName,
+        Bucket: config.bucketName,
         Prefix: `${prefix}`,
         Delimiter: '/',
         MaxKeys: 2147483647, // Maximum allowed by S3 API
@@ -93,7 +93,7 @@ async function getGcpModels(req, res) {
     prefix = prefix.slice(0, prefix.length - 1);
   }
   try {
-    let bucket = gcs.bucket(config.gcp.bucketName);
+    let bucket = gcs.bucket(config.bucketName);
     let allModels = [];
     let models = [];
     await getGcpKeys(bucket, config.model.prefix, models);

--- a/server/controllers/upload.controller.js
+++ b/server/controllers/upload.controller.js
@@ -11,7 +11,7 @@ const storage = new Storage({
 });
 
 function gcpUpload(req, res, next) {
-  const bucket = storage.bucket(config.gcp.bucketName);
+  const bucket = storage.bucket(config.bucketName);
   if (!req.file) {
     return res.sendStatus(httpStatus.BAD_REQUEST);
   }


### PR DESCRIPTION
Deprecate `CLOUD_PROVIDER`, `GCLOUD_STORAGE_BUCKET` and `AWS_S3_BUCKET` in favor of a single `STORAGE_BUCKET` that includes the bucket protocol (e.g. `s3://`). This simplifies the required environment variables.