### PR TITLE
Refactor Caliban to DeepCell Label.

### DIFF
--- a/src/About/About.js
+++ b/src/About/About.js
@@ -104,14 +104,14 @@ class About extends React.Component {
                 aria-controls="panel-data-1-content"
                 id="panel-data-1-header"
               >
-                <Typography className={classes.heading}>caliban</Typography>
+                <Typography className={classes.heading}>DeepCell Label</Typography>
                 {/* <Typography className={classes.secondaryHeading}>I am an accordion</Typography> */}
               </AccordionSummary>
               <AccordionDetails>
                 <Typography>
-                  <a href="https://github.com/vanvalenlab/caliban" target="_blank" rel="noreferrer">Caliban</a> is our training data curation tool.
+                  <a href="https://github.com/vanvalenlab/deepcell-label" target="_blank" rel="noreferrer">DeepCell Label</a> is our training data curation tool.
                   It provides an inutitive UI for users to create annotations from scratch or to correct model predictions, to faciliate the creation of large, high-quality datasets.
-                  Caliban can be deployed locally or on the cloud.
+                  DeepCell Label can be deployed locally or on the cloud.
                 </Typography>
               </AccordionDetails>
             </Accordion>

--- a/src/Faq/Faq.js
+++ b/src/Faq/Faq.js
@@ -167,8 +167,8 @@ class Faq extends React.Component {
                   Can you help me annotate my data?
                 </Typography>
                 <Typography variant="body1" align="left" color="textPrimary" gutterBottom>
-                  Yes! Our training data was created using <Link href="https://github.com/vanvalenlab/Caliban" target="_blank" rel="noopener noreferrer">Caliban</Link>, a tool for creating segmentation masks for images.
-                  Caliban is an open-source web application that can integrate with crowd-sourcing platforms like <Link href="https://www.figure-eight.com" target="_blank" rel="noopener noreferrer">Figure Eight</Link>.
+                  Yes! Our training data was created using <Link href="https://github.com/vanvalenlab/deepcell-label" target="_blank" rel="noopener noreferrer">DeepCell Label</Link>, a tool for creating segmentation masks for images.
+                  DeepCell Label is an open-source web application that can integrate with crowd-sourcing platforms like <Link href="https://www.figure-eight.com" target="_blank" rel="noopener noreferrer">Figure Eight</Link>.
                 </Typography>
               </Paper>
 


### PR DESCRIPTION
Caliban is now DeepCell Label, and this should be reflected in the FAQ and About pages.