### PR TITLE
Replace `ScaleForm` with new `ResolutionDropdown`.

### DIFF
--- a/src/Predict/ChannelForm.js
+++ b/src/Predict/ChannelForm.js
@@ -3,6 +3,7 @@ import { PropTypes } from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
+import Grid from '@material-ui/core/Grid';
 import InputLabel from '@material-ui/core/InputLabel';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -63,15 +64,18 @@ export default function ChannelForm(props) {
 
   return (
     <FormGroup>
-      {targetChannels && Object.keys(targetChannels).map((t, i) => (
-        <ChannelDropdown
-          label={`${t}`}
-          key={i}
-          value={targetChannels[t]}
-          channels={channels}
-          onChange={e => onChange(e.target.value, t)}
-        />
-      ))}
+      <Grid container spacing={1} xs={12}>
+        {targetChannels && Object.keys(targetChannels).map((t, i) => (
+          <Grid item key={i}>
+            <ChannelDropdown
+              label={`${t}`}
+              value={targetChannels[t]}
+              channels={channels}
+              onChange={e => onChange(e.target.value, t)}
+            />
+          </Grid>
+        ))}
+      </Grid>
     </FormGroup>
   );
 }

--- a/src/Predict/JobCard.js
+++ b/src/Predict/JobCard.js
@@ -27,7 +27,6 @@ export default function JobCard({
   name = 'Model',
   model = 'The Model takes in single-channeled images.',
   inputs = 'An image file.',
-  resolution = '20X (0.5 μm)',
   thumbnail = 'https://bit.ly/2ZxBrQ1',
 }) {
 
@@ -51,9 +50,6 @@ export default function JobCard({
         </Typography>
         <Typography variant="subtitle1">
           <strong>Inputs:</strong> { inputs }
-        </Typography>
-        <Typography variant="subtitle1">
-          <strong>Resolution:</strong> { resolution }
         </Typography>
       </CardContent>
       <CardActions>

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -12,7 +12,7 @@ import queryString from 'query-string';
 import FileUpload from './FileUpload';
 import JobCard from './JobCard';
 import ModelDropdown from './ModelDropdown';
-import ScaleForm from './ScaleForm';
+import ResolutionDropdown from './ResolutionDropdown';
 import ChannelForm from './ChannelForm';
 import jobData from './jobData';
 
@@ -50,8 +50,8 @@ export default function Predict() {
   const [errorText, setErrorText] = useState('');
   const [progress, setProgress] = useState(0);
   const [selectedJobType, setSelectedJobType] = useState('');
-  const [isAutoRescaleEnabled, setIsAutoRescaleEnabled] = useState(true);
   const [displayRescaleForm, setDisplayRescaleForm] = useState(false);
+  const [modelResolution, setModelResolution] = useState(0.5);
   const [scale, setScale] = useState(1);
   const [status, setStatus] = useState('');
 
@@ -72,6 +72,7 @@ export default function Predict() {
   useEffect(() => {
     if (selectedJobType) {
       setDisplayRescaleForm(jobData[selectedJobType].scaleEnabled);
+      setModelResolution(jobData[selectedJobType].modelResolution);
       const jobTargets = jobData[selectedJobType].requiredChannels;
       setTargetChannels(jobTargets.reduce((result, item, index) => {
         result[item] = channels[index];
@@ -156,7 +157,7 @@ export default function Predict() {
         uploadedName: uploadedFileName,
         imageUrl: imageUrl,
         jobType: selectedJobType,
-        dataRescale: isAutoRescaleEnabled ? (displayRescaleForm ? '' : '1') : scale,
+        dataRescale: scale,
         channels: (jobData[selectedJobType].requiredChannels).map(
           c => channelValues[targetChannels[c]]).join(','),
       }
@@ -219,11 +220,13 @@ export default function Predict() {
                   </Grid>
                   
                   { displayRescaleForm && <Grid item lg>
-                    <ScaleForm
-                      checked={isAutoRescaleEnabled}
+                    <Typography>
+                      Image Resolution
+                    </Typography>
+                    <ResolutionDropdown
+                      modelMpp={modelResolution}
                       scale={scale}
-                      onCheckboxChange={e => setIsAutoRescaleEnabled(Boolean(e.target.checked))}
-                      onScaleChange={e => setScale(Number(e.target.value))}
+                      onChange={setScale}
                     />
                   </Grid>
                   }

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -196,16 +196,30 @@ export default function Predict() {
               {/* Job Options section */}
               <Grid container>
                 <Paper className={classes.paper}>
-                  <Grid container>
+                  <Grid container spacing={1}>
+
+                    {/* Prediction type and Image Resolution in a column */}
                     <Grid item md={6}>
-                      <Typography>
-                        Prediction Type
-                      </Typography>
-                      <ModelDropdown
-                        value={selectedJobType}
-                        onChange={setSelectedJobType}
-                        onError={setErrorText}
-                      />
+                      <Grid container direction={'column'} spacing={1}>
+                        <Grid item>
+                          <Typography>
+                            Prediction Type
+                          </Typography>
+                          <ModelDropdown
+                            value={selectedJobType}
+                            onChange={setSelectedJobType}
+                            onError={setErrorText}
+                          />
+                        </Grid>
+                        { displayRescaleForm && <Grid item lg>
+                          <Typography>Image Resolution</Typography>
+                          <ResolutionDropdown
+                            modelMpp={modelResolution}
+                            scale={scale}
+                            onChange={setScale}
+                          />
+                        </Grid>}
+                      </Grid>
                     </Grid>
                     <Grid item md={6}>
                       {/* <Typography align="right">
@@ -218,18 +232,6 @@ export default function Predict() {
                       />
                     </Grid>
                   </Grid>
-                  
-                  { displayRescaleForm && <Grid item lg>
-                    <Typography>
-                      Image Resolution
-                    </Typography>
-                    <ResolutionDropdown
-                      modelMpp={modelResolution}
-                      scale={scale}
-                      onChange={setScale}
-                    />
-                  </Grid>
-                  }
                 </Paper>
               </Grid>
 

--- a/src/Predict/ResolutionDropdown.js
+++ b/src/Predict/ResolutionDropdown.js
@@ -33,9 +33,7 @@ export default function ResolutionDropdown({
           open={isOpen}
           onClose={() => setIsOpen(false)}
           onOpen={() => setIsOpen(true)}
-          onChange={e => {
-            onChange(e.target.value);
-          }}
+          onChange={e => onChange(e.target.value)}
         >
           {Object.entries(zoomToMpp).map(([zoom, mpp], i) => {
             return (

--- a/src/Predict/ResolutionDropdown.js
+++ b/src/Predict/ResolutionDropdown.js
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { PropTypes } from 'prop-types';
+import FormControl from '@material-ui/core/FormControl';
+import FormGroup from '@material-ui/core/FormGroup';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+
+export default function ResolutionDropdown({
+  modelMpp = 0.5,
+  scale = 1,
+  onChange = () => {},
+}) {
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  // values determined from 
+  // https://openwetware.org/wiki/Methods_to_determine_the_size_of_an_object_in_microns
+  // using 0.5 ~= 20x as the starting point
+  const zoomToMpp = {
+    '10x': 1,
+    '20x': 0.5,
+    '40x': 0.25,
+    '60x': 0.1667,
+  };
+
+  return (
+    <FormGroup row>
+      <FormControl>
+        <Select
+          labelId="input-resolution-select-label"
+          id="input-resolution-select"
+          value={scale}
+          open={isOpen}
+          onClose={() => setIsOpen(false)}
+          onOpen={() => setIsOpen(true)}
+          onChange={e => {
+            onChange(e.target.value);
+          }}
+        >
+          {Object.entries(zoomToMpp).map(([zoom, mpp], i) => {
+            return (
+              <MenuItem value={mpp / modelMpp} key={i}>
+                {zoom} ({mpp} μm/pixel)
+              </MenuItem>
+            );
+          })}
+        </Select>
+      </FormControl>
+    </FormGroup>
+  );
+}
+
+ResolutionDropdown.propTypes = {
+  scale: PropTypes.number,
+  modelMpp: PropTypes.number,
+  onChange: PropTypes.func,
+};

--- a/src/Predict/ResolutionDropdown.test.js
+++ b/src/Predict/ResolutionDropdown.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ResolutionDropdown from './ResolutionDropdown';
+
+describe('<ResolutionDropdown/> component tests', () => {
+
+  it('<ResolutionDropdown/> renders with default values.', () => {
+    const { getByLabelText } = render(<ResolutionDropdown modelMpp={0.5} scale={1} />);
+    const element = getByLabelText(/20x/i);
+    expect(element).toBeInTheDocument();
+  });
+
+  it('<ResolutionDropdown/> renders with overridden values.', () => {
+    const { getByText } = render(<ResolutionDropdown modelMpp={0.25} scale={1} />);
+    const element = getByText(/40x/i);
+    expect(element).toBeInTheDocument();
+  });
+
+});

--- a/src/Predict/jobData.js
+++ b/src/Predict/jobData.js
@@ -5,42 +5,37 @@ const jobCards = {
     name: 'Nuclear Segmentation',
     model: 'The nuclear model performs nuclear segmentation of cell culture data.',
     inputs: 'A nuclear channel image.',
-    resolution: 'Nuclear Segmentation expects data that is approximately 20X (0.65 μm per pixel)',
+    resolution: 'Nuclear Segmentation expects data that is approximately 20X (0.65 μm/pixel)',
     thumbnail: 'thumbnails/HeLa_nuclear_color.png',
-    scaleEnabled: false,
+    scaleEnabled: true,
     requiredChannels: ['nuclei'],
-  },
-  multiplex: {
-    file: 'tiff_stack_examples/vectra_breast_cancer.tif',
-    name: 'Mesmer',
-    model: 'Mesmer performs whole-cell segmentation of multiplex tissue data.',
-    inputs: 'An image containing both a nuclear marker and a membrane/cytoplasm marker.',
-    resolution: 'Mesmer expects data that is approximately 20X (0.5 μm per pixel)',
-    thumbnail: 'thumbnails/breast_vectra.png',
-    scaleEnabled: false,
-    requiredChannels: ['nuclei', 'cytoplasm'],
+    modelResolution: 0.5,
   },
   tracking: {
     file: 'tiff_stack_examples/3T3_nuc_example_256.tif',
     name: 'Cell Tracking',
     model: 'The cell tracking model segments and tracks objects over time and creates a lineage file for division information.',
     inputs: 'A single-channel image stack (3D TIFF).',
-    resolution: 'Cell Tracking expects data that is approximately 20X (0.65 μm per pixel)',
+    resolution: 'Cell Tracking expects data that is approximately 20X (0.65 μm/pixel)',
     thumbnail: 'thumbnails/3T3_nuc_example_256.png',
     scaleEnabled: true,
     requiredChannels: ['nuclei'],
+    modelResolution: 0.5,
   },
-  // TODO: this is a stop gap to support both multiplex and mesmer names
   mesmer: {
     file: 'tiff_stack_examples/vectra_breast_cancer.tif',
     name: 'Mesmer',
     model: 'Mesmer performs whole-cell segmentation of multiplex tissue data.',
     inputs: 'An image containing both a nuclear marker and a membrane/cytoplasm marker.',
-    resolution: 'Mesmer expects data that is approximately 20X (0.5 μm per pixel)',
+    resolution: 'Mesmer expects data that is approximately 20X (0.5 μm/pixel)',
     thumbnail: 'thumbnails/breast_vectra.png',
-    scaleEnabled: false,
+    scaleEnabled: true,
     requiredChannels: ['nuclei', 'cytoplasm'],
+    modelResolution: 0.5,
   },
 };
+
+// TODO: this is a stop gap to support both multiplex and mesmer names
+jobCards.multilplex = jobCards.mesmer;
 
 export default jobCards;


### PR DESCRIPTION
As discussed in #165, the `ScaleForm` is a bit too unintuitive for users. It's not clear what the correct "scale" should be. This PR replaces the `ScaleForm` with a manual dropdown with common microns-per-pixel values (and the zoom level used with them). This way, the user can select if their data is 40x or 10x instead of trying to guess at the correct scale.

I think there is still room for a manual input form for image mpp, but for now, I think that the ballpark resize values will be helpful and intuitive.

Fixes #165