### PR TITLE
Parametrize whether to open job results in Label

### DIFF
--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -115,11 +115,11 @@ ProgressBar.propTypes = {
   status: PropTypes.string.isRequired,
 };
 
-const JobCompleteButtons = ({ imageUrl, downloadUrl, dimensionOrder }) => {
+const JobCompleteButtons = ({ openInLabel, imageUrl, downloadUrl, dimensionOrder }) => {
   return (
     <div>
       <DownloadButton downloadUrl={downloadUrl} />
-      {imageUrl.split('.').pop() !== 'zip' &&
+      {openInLabel && imageUrl.split('.').pop() !== 'zip' &&
         <OpenInLabelButton
           imageUrl={imageUrl}
           downloadUrl={downloadUrl}
@@ -130,6 +130,7 @@ const JobCompleteButtons = ({ imageUrl, downloadUrl, dimensionOrder }) => {
 };
 
 JobCompleteButtons.propTypes = {
+  openInLabel: PropTypes.bool.isRequired,
   imageUrl: PropTypes.string.isRequired,
   downloadUrl: PropTypes.string.isRequired,
   dimensionOrder: PropTypes.string.isRequired,
@@ -224,6 +225,7 @@ export default function Predict() {
   const [errorText, setErrorText] = useState('');
   const [progress, setProgress] = useState(0);
   const [selectedJobType, setSelectedJobType] = useState('');
+  const [submittedJobType, setSubmittedJobType] = useState('');
   const [displayRescaleForm, setDisplayRescaleForm] = useState(false);
   const [modelResolution, setModelResolution] = useState(0.5);
   const [scale, setScale] = useState(1);
@@ -355,6 +357,7 @@ export default function Predict() {
     }
     setSubmitted(true);
     setStatus('submitting');
+    setSubmittedJobType(selectedJobType);
     predict();
   };
 
@@ -467,6 +470,7 @@ export default function Predict() {
           {/* Download results, Open in Label, and Retry buttons */}
           { downloadUrl !== null &&
             <JobCompleteButtons
+              openInLabel={jobData[submittedJobType].canOpenInLabel}
               imageUrl={imageUrl}
               downloadUrl={downloadUrl}
               dimensionOrder={dimensionOrder}

--- a/src/Predict/jobData.js
+++ b/src/Predict/jobData.js
@@ -10,6 +10,7 @@ const jobCards = {
     scaleEnabled: true,
     requiredChannels: ['nuclei'],
     modelResolution: 0.5,
+    canOpenInLabel: true,
   },
   caliban: {
     file: 'tiff_stack_examples/3T3_nuc_example_256.tif',
@@ -21,6 +22,7 @@ const jobCards = {
     scaleEnabled: true,
     requiredChannels: ['nuclei'],
     modelResolution: 0.5,
+    canOpenInLabel: true,
   },
   mesmer: {
     file: 'tiff_stack_examples/vectra_breast_cancer.tif',
@@ -32,6 +34,7 @@ const jobCards = {
     scaleEnabled: true,
     requiredChannels: ['nuclei', 'cytoplasm'],
     modelResolution: 0.5,
+    canOpenInLabel: true,
   },
   polaris: {
     file: 'tiff_stack_examples/MERFISH_example.tiff',
@@ -42,7 +45,8 @@ const jobCards = {
     thumbnail: 'thumbnails/FISH_example.png',
     scaleEnabled: true,
     requiredChannels: ['spots'],
-    modelResolution: 0.1
+    modelResolution: 0.1,
+    canOpenInLabel: false,
   },
 };
 


### PR DESCRIPTION
This adds data to each each job type on whether opening results in DeepCell Label is supported. It adds some internal state to track what job type was last submitted (so switching the selected type to mesmer after getting polaris results won't show the button), and adds a `canOpenInLabel` field to each jobData.

I'm working on adding tests for this addition by testing that a completed mesmer job shows the button while a completed polaris job does not, but it's taking some time to figure out how to mock the API responses to make the Predict component reach it's completed state. It seems like first `/api/jobtypes` is called, then `/api/predict`, then `/api/redis`. @MekWarrior do you know where I can look up the expected responses for the API? We can also wait on adding tests if it's too much of a challenge for now