### PR TITLE
Add more options for Polaris jobs

### DIFF
--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -109,13 +109,14 @@ async function predict(req, res) {
       'preprocess_function', data.preprocessFunction || '',
       'cuts', data.cuts || '0', // to split up very large images
       'url', data.imageUrl || '', // unused?
-      'scale', data.dataRescale || '',
       'label', data.dataLabel || '',
       'status', 'new',
       'created_at', now,
       'updated_at', now,
       'identity_upload', config.hostname,
-      'channels', data.channels || '',
+      'channels', data.jobForm.selectedChannels || '',
+      'scale', data.jobForm.scale || '',
+      'segmentation_type', data.jobForm.segmentationType || '',
     ]);
     await redis.lpush(queueName, redisKey);
     return res.status(httpStatus.OK).send({ hash: redisKey });

--- a/server/controllers/predict.controller.js
+++ b/server/controllers/predict.controller.js
@@ -114,9 +114,9 @@ async function predict(req, res) {
       'created_at', now,
       'updated_at', now,
       'identity_upload', config.hostname,
-      'channels', data.jobForm.selectedChannels || '',
-      'scale', data.jobForm.scale || '',
-      'segmentation_type', data.jobForm.segmentationType || '',
+      'channels', data.jobForm?.selectedChannels || '',
+      'scale', data.jobForm?.scale || '',
+      'segmentation_type', data.jobForm?.segmentationType || '',
     ]);
     await redis.lpush(queueName, redisKey);
     return res.status(httpStatus.OK).send({ hash: redisKey });

--- a/src/Predict/ChannelForm.js
+++ b/src/Predict/ChannelForm.js
@@ -8,13 +8,13 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 
 function ChannelDropdown(props) {
-  const { label, value, onChange } = props;
+  const { label, value, onChange, required } = props;
   const [isOpen, setIsOpen] = useState(false);
   const channels = ['red', 'green', 'blue'];
 
   return (
     <FormControl variant='standard' fullWidth>
-      <InputLabel margin='dense' htmlFor={`${label}-input`}>{`${label} channel`}</InputLabel>
+      <InputLabel shrink margin='dense' htmlFor={`${label}-input`}>{`${label} channel`}</InputLabel>
       <Select
         size='small'
         labelId={`${label}-input`}
@@ -23,10 +23,12 @@ function ChannelDropdown(props) {
         onOpen={() => setIsOpen(true)}
         onChange={onChange}
         value={value}
-        autoWidth={true}
+        // autoWidth={true}
+        displayEmpty
         sx={{ textTransform: 'capitalize' }}
       >
-        {channels.map((c, i) => (
+        {!required && <MenuItem value={null}>None</MenuItem>}
+        {channels.map((c , i) => (
           <MenuItem value={i} key={c} sx={{ textTransform: 'capitalize' }}>
             Channel {i+1} ({c})
           </MenuItem>
@@ -41,22 +43,24 @@ ChannelDropdown.propTypes = {
   value: PropTypes.number,
   channels: PropTypes.array,
   onChange: PropTypes.func,
+  required: PropTypes.bool, 
 };
 
 
 export default function ChannelForm(props) {
 
-  const { selectedChannels, requiredChannels, onChange } = props;
+  const { channels, selectedChannels, requiredChannels, onChange } = props;
   return (
     <FormGroup>
-      <Grid container spacing={1} xs={12}>
+      <Grid container spacing={1} xs={12} direction='column'>
         {selectedChannels && selectedChannels.map((channel, i) => (
-          <Grid item key={i}>
+          <Grid item key={channels[i]}>
             <ChannelDropdown
-              label={`${requiredChannels[i]}`}
+              label={`${channels[i]}`}
               value={channel}
               index={i}
               onChange={e => onChange(e.target.value, i)}
+              required={requiredChannels[i]}
             />
           </Grid>
         ))}
@@ -66,6 +70,7 @@ export default function ChannelForm(props) {
 }
 
 ChannelForm.propTypes = {
+  channels: PropTypes.array,
   requiredChannels: PropTypes.array,
   selectedChannels: PropTypes.array,
   onChange: PropTypes.func,

--- a/src/Predict/ChannelForm.js
+++ b/src/Predict/ChannelForm.js
@@ -8,9 +8,9 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 
 function ChannelDropdown(props) {
-
-  const { label, value, channels, onChange } = props;
+  const { label, value, onChange } = props;
   const [isOpen, setIsOpen] = useState(false);
+  const channels = ['red', 'green', 'blue'];
 
   return (
     <FormControl variant='standard' fullWidth>
@@ -27,7 +27,7 @@ function ChannelDropdown(props) {
         sx={{ textTransform: 'capitalize' }}
       >
         {channels.map((c, i) => (
-          <MenuItem value={c} key={i} sx={{ textTransform: 'capitalize' }}>
+          <MenuItem value={i} key={c} sx={{ textTransform: 'capitalize' }}>
             Channel {i+1} ({c})
           </MenuItem>
         ))}
@@ -38,7 +38,7 @@ function ChannelDropdown(props) {
 
 ChannelDropdown.propTypes = {
   label: PropTypes.string,
-  value: PropTypes.string,
+  value: PropTypes.number,
   channels: PropTypes.array,
   onChange: PropTypes.func,
 };
@@ -46,18 +46,17 @@ ChannelDropdown.propTypes = {
 
 export default function ChannelForm(props) {
 
-  const { targetChannels, channels, onChange } = props;
-
+  const { selectedChannels, requiredChannels, onChange } = props;
   return (
     <FormGroup>
       <Grid container spacing={1} xs={12}>
-        {targetChannels && Object.keys(targetChannels).map((t, i) => (
+        {selectedChannels && selectedChannels.map((channel, i) => (
           <Grid item key={i}>
             <ChannelDropdown
-              label={`${t}`}
-              value={targetChannels[t]}
-              channels={channels}
-              onChange={e => onChange(e.target.value, t)}
+              label={`${requiredChannels[i]}`}
+              value={channel}
+              index={i}
+              onChange={e => onChange(e.target.value, i)}
             />
           </Grid>
         ))}
@@ -67,7 +66,7 @@ export default function ChannelForm(props) {
 }
 
 ChannelForm.propTypes = {
-  channels: PropTypes.array,
-  targetChannels: PropTypes.object,
+  requiredChannels: PropTypes.array,
+  selectedChannels: PropTypes.array,
   onChange: PropTypes.func,
 };

--- a/src/Predict/ChannelForm.test.js
+++ b/src/Predict/ChannelForm.test.js
@@ -11,7 +11,8 @@ describe('<ChannelForm/> component tests', () => {
     const target2 = 'channelLabel2';
     const { getByText } = render(
       <ChannelForm
-        requiredChannels={[target1, target2]}
+        channels={[target1, target2]}
+        requiredChannels={[true, true]}
         selectedChannels={[0, 1]}
       />
     );

--- a/src/Predict/ChannelForm.test.js
+++ b/src/Predict/ChannelForm.test.js
@@ -11,8 +11,8 @@ describe('<ChannelForm/> component tests', () => {
     const target2 = 'channelLabel2';
     const { getByText } = render(
       <ChannelForm
-        targetChannels={{ [target1]: 'R', [target2]: 'G' }}
-        channels={['B', 'R', 'G', 'B']}
+        requiredChannels={[target1, target2]}
+        selectedChannels={[0, 1]}
       />
     );
     const element1 = getByText(`${target1} channel`);

--- a/src/Predict/MesmerForm.js
+++ b/src/Predict/MesmerForm.js
@@ -15,8 +15,9 @@ MesmerForm.propTypes = {
 
 export default function MesmerForm({ selectJobType, setJobForm }) {
   const modelResolution = jobData.mesmer.modelResolution;
-  const requiredChannels = jobData.mesmer.requiredChannels;
-  const [selectedChannels, setSelectedChannels] = useState([...Array(requiredChannels.length).keys()]);
+  const channels = jobData.mesmer.requiredChannels;
+  const [requiredChannels] = useState(Array(channels.length).fill(true));
+  const [selectedChannels, setSelectedChannels] = useState([...Array(channels.length).keys()]);
   const [scale, setScale] = useState(1);
 
   const updateSelectedChannels = (value, i) => {
@@ -49,6 +50,7 @@ export default function MesmerForm({ selectJobType, setJobForm }) {
           </Grid>
           <Grid item md={6}>
             <ChannelForm
+              channels={channels}
               requiredChannels={requiredChannels}
               selectedChannels={selectedChannels}
               onChange={updateSelectedChannels}

--- a/src/Predict/MesmerForm.js
+++ b/src/Predict/MesmerForm.js
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+// import axios from 'axios';
+import ResolutionDropdown from './ResolutionDropdown';
+import ChannelForm from './ChannelForm';
+import jobData from './jobData';
+
+MesmerForm.propTypes = {
+  selectJobType: PropTypes.element.isRequired,
+  setJobForm: PropTypes.func.isRequired,
+};
+
+export default function MesmerForm({ selectJobType, setJobForm }) {
+  const modelResolution = jobData.mesmer.modelResolution;
+  const requiredChannels = jobData.mesmer.requiredChannels;
+  const [selectedChannels, setSelectedChannels] = useState([...Array(requiredChannels.length).keys()]);
+  const [scale, setScale] = useState(1);
+
+  const updateSelectedChannels = (value, i) => {
+    setSelectedChannels((selectedChannels) => { 
+      selectedChannels[i] = value;
+      return [...selectedChannels];
+    });
+  };
+
+  useEffect(() => {
+    setJobForm({ scale, selectedChannels: selectedChannels.join(',') });
+  }, [selectedChannels, scale]);
+
+  return (
+    <Grid container>
+      <Paper sx={{ p: 4, height: '100%', width: '100%' }}>
+        <Grid container spacing={1}>
+          <Grid item md={6}>
+            <Grid container direction={'column'} spacing={1}>
+              {selectJobType}
+              <Grid item lg>
+                <Typography>Image Resolution</Typography>
+                <ResolutionDropdown
+                  modelMpp={modelResolution}
+                  scale={scale}
+                  onChange={setScale}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item md={6}>
+            <ChannelForm
+              requiredChannels={requiredChannels}
+              selectedChannels={selectedChannels}
+              onChange={updateSelectedChannels}
+            />
+          </Grid>
+        </Grid>
+      </Paper>
+    </Grid>
+  );
+}
+

--- a/src/Predict/ModelDropdown.js
+++ b/src/Predict/ModelDropdown.js
@@ -1,30 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { PropTypes } from 'prop-types';
 import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
-import axios from 'axios';
 
 export default function ModelDropdown(props) {
 
-  const { value, onChange, onError } = props;
+  const { value, onChange, options } = props;
 
   const [isOpen, setIsOpen] = useState(false);
-  const [allJobTypes, setAllJobTypes] = useState([]);
-
-  const getAllJobTypes = () => {
-    axios({
-      method: 'get',
-      url: '/api/jobtypes'
-    }).then((response) => {
-      setAllJobTypes(response.data.jobTypes);
-      onChange(response.data.jobTypes[0]);
-    }).catch(error => {
-      onError(`Failed to get job types due to error: ${error}`);
-    });
-  };
-
-  useEffect(() => getAllJobTypes(), [0]);
 
   return (
     <FormControl>
@@ -38,9 +22,9 @@ export default function ModelDropdown(props) {
         sx={{ textTransform: 'capitalize' }}
         variant="standard"
       >
-        {allJobTypes.map((job, i) => (
-          <MenuItem value={job} sx={{ textTransform: 'capitalize' }} key={i}>
-            {job}
+        {options.map((jobType, i) => (
+          <MenuItem value={jobType} sx={{ textTransform: 'capitalize' }} key={i}>
+            {jobType}
           </MenuItem>
         ))}
       </Select>
@@ -51,5 +35,5 @@ export default function ModelDropdown(props) {
 ModelDropdown.propTypes = {
   value: PropTypes.string,
   onChange: PropTypes.func,
-  onError: PropTypes.func,
+  options: PropTypes.array,
 };

--- a/src/Predict/PolarisForm.js
+++ b/src/Predict/PolarisForm.js
@@ -1,0 +1,118 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+// import axios from 'axios';
+import ChannelForm from './ChannelForm';
+// import jobData from './jobData';
+import FormControl from '@mui/material/FormControl';
+import FormGroup from '@mui/material/FormGroup';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+
+SelectSegmentation.propTypes = {
+  value: PropTypes.string,
+  options: PropTypes.array,
+  onChange: PropTypes.func,
+};
+
+function SelectSegmentation({
+  value = 'none',
+  options = ['none', 'tissue', 'cell culture'],
+  onChange = () => {},
+}) {
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <FormGroup row>
+      <FormControl>
+        <Select
+          size="small"
+          labelId="input-resolution-select-label"
+          id="input-resolution-select"
+          value={value}
+          open={isOpen}
+          onClose={() => setIsOpen(false)}
+          onOpen={() => setIsOpen(true)}
+          onChange={e => onChange(e.target.value)}
+          variant="standard"
+          sx={{ textTransform: 'capitalize' }}
+        >
+          {options.map((opt => <MenuItem value={opt} key={opt} sx={{ textTransform: 'capitalize' }}>{opt}</MenuItem>))}
+        </Select>
+      </FormControl>
+    </FormGroup>
+  );
+}
+
+PolarisForm.propTypes = {
+  selectJobType: PropTypes.element.isRequired,
+  setJobForm: PropTypes.func.isRequired,
+};
+
+export default function PolarisForm({ selectJobType, setJobForm }) {
+  const [requiredChannels, setRequiredChannels] = useState([]);
+  const [selectedChannels, setSelectedChannels] = useState([]); // which channel to use for each required channel
+  const [segmentationType, setSegmentationType] = useState('none');
+  const segmentationOptions = ['none', 'tissue', 'cell culture'];
+
+  useEffect(() => {
+    if (segmentationType === 'none') {
+      setRequiredChannels([]);
+    } else if (segmentationType === 'tissue') {
+      setRequiredChannels(['spots', 'nuclei', 'cytoplasm']);
+    } else if (segmentationType === 'cell culture') {
+      setRequiredChannels(['spots', 'nuclei', 'cytoplasm']);
+    } else {
+      setRequiredChannels([]);
+    }
+  }, [segmentationType]);
+
+  useEffect(() => {
+    setSelectedChannels([...Array(requiredChannels.length).keys()]);
+  }, [requiredChannels]);
+
+  useEffect(() => {
+    setJobForm({ selectedChannels: selectedChannels.join(','), segmentationType });
+  }, [segmentationType, selectedChannels]);
+
+  const updateSelectedChannels = (value, i) => {
+    setSelectedChannels((selectedChannels) => { 
+      selectedChannels[i] = value;
+      return [...selectedChannels];
+    });
+  };
+
+  return (
+    <Grid container>
+      <Paper sx={{ p: 4, height: '100%', width: '100%' }}>
+        <Grid container spacing={1}>
+          <Grid item md={6}>
+            <Grid container direction={'column'} spacing={1}>
+              {selectJobType}
+              <Grid item lg>
+                <Typography>Segmentation Type</Typography>
+                <SelectSegmentation
+                  value={segmentationType}
+                  options={segmentationOptions}
+                  onChange={setSegmentationType}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item md={6}>
+            <ChannelForm
+              requiredChannels={requiredChannels}
+              selectedChannels={selectedChannels}
+              onChange={updateSelectedChannels}
+            />
+          </Grid>
+        </Grid>
+      </Paper>
+    </Grid>
+
+  );
+}
+

--- a/src/Predict/PolarisForm.js
+++ b/src/Predict/PolarisForm.js
@@ -53,26 +53,31 @@ PolarisForm.propTypes = {
 };
 
 export default function PolarisForm({ selectJobType, setJobForm }) {
+  const [channels, setChannels] = useState([]);
   const [requiredChannels, setRequiredChannels] = useState([]);
-  const [selectedChannels, setSelectedChannels] = useState([]); // which channel to use for each required channel
+  const [selectedChannels, setSelectedChannels] = useState([]);
   const [segmentationType, setSegmentationType] = useState('none');
   const segmentationOptions = ['none', 'tissue', 'cell culture'];
 
   useEffect(() => {
     if (segmentationType === 'none') {
+      setChannels([]);
       setRequiredChannels([]);
+      setSelectedChannels([]);
     } else if (segmentationType === 'tissue') {
-      setRequiredChannels(['spots', 'nuclei', 'cytoplasm']);
+      setChannels(['spots', 'nuclei', 'cytoplasm']);
+      setRequiredChannels([true, true, true]);
+      setSelectedChannels([0, 1, 2]);
     } else if (segmentationType === 'cell culture') {
-      setRequiredChannels(['spots', 'nuclei', 'cytoplasm']);
+      setChannels(['spots', 'nuclei', 'cytoplasm']);
+      setRequiredChannels([true, false, false]);
+      setSelectedChannels([0, null, null]);
     } else {
+      setChannels([]);
       setRequiredChannels([]);
+      setSelectedChannels([]);
     }
   }, [segmentationType]);
-
-  useEffect(() => {
-    setSelectedChannels([...Array(requiredChannels.length).keys()]);
-  }, [requiredChannels]);
 
   useEffect(() => {
     setJobForm({ selectedChannels: selectedChannels.join(','), segmentationType });
@@ -104,8 +109,9 @@ export default function PolarisForm({ selectJobType, setJobForm }) {
           </Grid>
           <Grid item md={6}>
             <ChannelForm
-              requiredChannels={requiredChannels}
+              channels={channels}
               selectedChannels={selectedChannels}
+              requiredChannels={requiredChannels}
               onChange={updateSelectedChannels}
             />
           </Grid>


### PR DESCRIPTION
This PR introduces two new components MesmerForm and PolarisForm that contain workflow specific forms so that those jobs can be parameterized. The behavior for mesmer is unchanged, which polaris can now pick what segmentation model to use and which channels to use segmentation.

Each Form component updates the jobForm object in the Predict component. We now send the jobForm object to the /predict route, which unpacks the form to send to the consumer. As we expand the supported workflows and the contents of the jobForm varies more, we'll need to revisit how the route handles the jobForm contents.

I've also refactored the ChannelForm to simplify the state for selected channels. Previously, there were four collaborating variables that tracked the selected channels including:

- targetChannels like `{ nuclei: 'red', cytoplasm: 'green' }`
- channels like `['red, 'green', 'blue']`
- channelValues like `{ red: 0, green: 1, blue: 2}`
- requiredChannels like `['nuclei', 'cytoplasm']`

These variables had to be transformed between each other with complex expression like
`Object.keys(channels).reduce((r, c) => Object.assign(r, { [channels[c]]: parseInt((r[channels[c]] || '').concat(c)) }), {})` and `requiredChannels.map(c => channelValues[targetChannels[c]])`.

I've refactored these variables into just requiredChannels `['nuclei', 'cytoplasm']` and selectedChannels `[0, 1]` which records which channel index should be used for each required channel. The selectedChannels are more similar to the data submitted to the api and is transformed with a simple expression `selectedChannels.join(',')` to yield `0,1`. I've also moved ['red', 'green', 'blue'] to an internal detail of the ChannelDropdown component as it is only used in display text.