### PR TITLE
Separate DimensionOrderDropdown and add tooltip

### DIFF
--- a/src/Predict/JobForm/DimensionOrderDropdown.js
+++ b/src/Predict/JobForm/DimensionOrderDropdown.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+// import axios from 'axios';
+import FormControl from '@mui/material/FormControl';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import { InputLabel, Tooltip, Box, Typography } from '@mui/material';
+import { HelpOutline } from '@mui/icons-material';
+
+function DimensionOrderDropdown(props) {
+  const { value, onChange } = props;
+  const orders = ['XY', 'BXY', 'CXY', 'BXYC', 'CXYB'];
+
+  return (
+    <FormControl variant='standard' fullWidth>
+      <InputLabel shrink margin='dense' htmlFor='dimension-order-input'>
+        <Box display='flex' alignItems='center' justifyContent='center'>
+          <Typography>dimension order</Typography>
+          <Tooltip
+            title={
+              'Set the order of the batch (B) and channel (C) dimensions. ' +
+              'Each channel and batch will be segmented and predicted separately.'
+            }
+          >
+            <HelpOutline fontSize='small' />
+          </Tooltip>
+        </Box>
+      </InputLabel>
+      <Select
+        size='small'
+        onChange={(e) => onChange(e.target.value)}
+        value={value}
+      >
+        {orders.map((o, i) => (
+          <MenuItem value={o} key={i}>
+            {o}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}
+
+DimensionOrderDropdown.propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+};
+
+export default DimensionOrderDropdown;

--- a/src/Predict/JobForm/SegmentationForm.js
+++ b/src/Predict/JobForm/SegmentationForm.js
@@ -7,35 +7,7 @@ import Typography from '@mui/material/Typography';
 import ResolutionDropdown from './ResolutionDropdown';
 import ChannelForm from './ChannelForm';
 import jobData from '../jobData';
-import FormControl from '@mui/material/FormControl';
-import MenuItem from '@mui/material/MenuItem';
-import Select from '@mui/material/Select';
-
-function DimensionOrderDropdown(props) {
-  const { value, onChange } = props;
-  const orders = ['XY', 'BXY', 'CXY', 'BXYC', 'CXYB'];
-
-  return (
-    <FormControl variant='standard' fullWidth>
-      <Select
-        size='small'
-        onChange={(e) => onChange(e.target.value)}
-        value={value}
-      >
-        {orders.map((o, i) => (
-          <MenuItem value={o} key={i}>
-            {o}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
-  );
-}
-
-DimensionOrderDropdown.propTypes = {
-  value: PropTypes.string,
-  onChange: PropTypes.func,
-};
+import DimensionOrderDropdown from './DimensionOrderDropdown';
 
 SegmentationForm.propTypes = {
   jobDropdown: PropTypes.element.isRequired,
@@ -87,7 +59,6 @@ export default function SegmentationForm({ jobDropdown, setJobForm }) {
           <Grid item md={6}>
             <Grid container direction={'column'} spacing={1}>
               <Grid item lg>
-                <Typography>Dimension Order</Typography>
                 <DimensionOrderDropdown
                   value={dimensionOrder}
                   onChange={setDimensionOrder}


### PR DESCRIPTION
This refactor the DimensionOrderDropdown component into its own file and adds a tooltip to clarify what it does. I also made the styling consistent with the channel form. Here's what it looks like
<img width="193" alt="Screen Shot 2022-04-26 at 3 00 02 PM" src="https://user-images.githubusercontent.com/40068392/165399704-c456a392-d72e-4d33-8654-e78e20ee6593.png">

