### PR TITLE
Change default job card settings to match example files

### DIFF
--- a/src/Predict/JobForm/PolarisForm.js
+++ b/src/Predict/JobForm/PolarisForm.js
@@ -63,7 +63,7 @@ export default function PolarisForm({ jobDropdown, setJobForm }) {
   const [channels, setChannels] = useState([]);
   const [requiredChannels, setRequiredChannels] = useState([]);
   const [selectedChannels, setSelectedChannels] = useState([]);
-  const [segmentationType, setSegmentationType] = useState('none');
+  const [segmentationType, setSegmentationType] = useState('cell culture');
   const segmentationOptions = ['none', 'tissue', 'cell culture'];
 
   useEffect(() => {
@@ -78,7 +78,7 @@ export default function PolarisForm({ jobDropdown, setJobForm }) {
     } else if (segmentationType === 'cell culture') {
       setChannels(['spots', 'nuclei', 'cytoplasm']);
       setRequiredChannels([true, false, false]);
-      setSelectedChannels([0, null, null]);
+      setSelectedChannels([0, 2, 1]);
     } else {
       setChannels([]);
       setRequiredChannels([]);

--- a/src/Predict/JobForm/SegmentationForm.js
+++ b/src/Predict/JobForm/SegmentationForm.js
@@ -18,7 +18,7 @@ export default function SegmentationForm({ jobDropdown, setJobForm }) {
   const modelResolution = jobData.segmentation.modelResolution;
   const channels = ['nuclei', 'cytoplasm'];
   const [requiredChannels] = useState(Array(channels.length).fill(false));
-  const [selectedChannels, setSelectedChannels] = useState([0,null]);
+  const [selectedChannels, setSelectedChannels] = useState([0, null]);
   const [dimensionOrder, setDimensionOrder] = useState('XYB');
   const [scale, setScale] = useState(1);
 

--- a/src/Predict/JobForm/SegmentationForm.js
+++ b/src/Predict/JobForm/SegmentationForm.js
@@ -18,10 +18,8 @@ export default function SegmentationForm({ jobDropdown, setJobForm }) {
   const modelResolution = jobData.segmentation.modelResolution;
   const channels = ['nuclei', 'cytoplasm'];
   const [requiredChannels] = useState(Array(channels.length).fill(false));
-  const [selectedChannels, setSelectedChannels] = useState([
-    ...Array(channels.length).keys(),
-  ]);
-  const [dimensionOrder, setDimensionOrder] = useState('BXY');
+  const [selectedChannels, setSelectedChannels] = useState([0,null]);
+  const [dimensionOrder, setDimensionOrder] = useState('XYB');
   const [scale, setScale] = useState(1);
 
   const updateSelectedChannels = (value, i) => {

--- a/src/Predict/jobData.js
+++ b/src/Predict/jobData.js
@@ -19,7 +19,7 @@ const jobCards = {
     model:
       'Caliban segments and tracks nuclei over time and creates a lineage file with division information.',
     inputs:
-      'A single-channel image stack of fluorescent nuclei (3D TIFF). Caliban expects data that is approximately 20X (0.65 μm/pixel).',
+      'A single-channel image stack of fluorescent nuclei (3D TIFF). Caliban expects data that is approximately 20X (0.65 μm/pixel). A maximum of 64 frames can be processed per movie.',
     resolution:
       'Caliban expects data that is approximately 20X (0.65 μm/pixel).',
     thumbnail: 'thumbnails/3T3_nuc_example_256.png',


### PR DESCRIPTION
This PR changes the default settings for the segmentation and Polaris job cards to match the settings needed to analyze the provided example files. 