### PR TITLE
Add visualizer to jobData for caliban

### DIFF
--- a/src/Predict/JobCompleteButtons/VisualizeButton.js
+++ b/src/Predict/JobCompleteButtons/VisualizeButton.js
@@ -11,9 +11,9 @@ function VisualizeButton({ url, imagesUrl, dimensionOrder, labelsUrl }) {
     formData.append('axes', dimensionOrder);
 
     // TODO: make mesmer and spots visualizers behave consistently
-    // spots: need to add /project
-    // mesmer: must be only base URL
-    const viewerUrl = url.includes('spots') ? `${url}/project` : url;
+    // mesmer (viewer.deepcell.org): must be only base URL
+    // spots, tracks, label, anolytics: need to add /project
+    const viewerUrl = url.includes('viewer') ? url : `${url}/project`;
     const newTab = window.open(viewerUrl, '_blank');
     axios({
       method: 'post',

--- a/src/Predict/jobData.js
+++ b/src/Predict/jobData.js
@@ -27,6 +27,7 @@ const jobCards = {
     channelEnabled: false, // Caliban form does not have a channel form so this value doesn't matter
     requiredChannels: ['nuclei'],
     modelResolution: 0.5,
+    visualizer: 'https://tracks.deepcell.org',
   },
   mesmer: {
     file: 'tiff_stack_examples/vectra_breast_cancer.tif',


### PR DESCRIPTION
This connects the kiosk frontend to the caliban visualizer on tracks.deepcell.org. Now that the field is set for caliban, the View Results button will appear after caliban jobs finish and will submit the result to the visualizer.