### PR TITLE
Update name of Polaris example file

### DIFF
--- a/src/Predict/JobForm/PolarisForm.js
+++ b/src/Predict/JobForm/PolarisForm.js
@@ -78,7 +78,7 @@ export default function PolarisForm({ jobDropdown, setJobForm }) {
     } else if (segmentationType === 'cell culture') {
       setChannels(['spots', 'nuclei', 'cytoplasm']);
       setRequiredChannels([true, false, false]);
-      setSelectedChannels([0, 2, 1]);
+      setSelectedChannels([0, 1, 2]);
     } else {
       setChannels([]);
       setRequiredChannels([]);

--- a/src/Predict/jobData.js
+++ b/src/Predict/jobData.js
@@ -44,7 +44,7 @@ const jobCards = {
     visualizer: 'https://viewer.deepcell.org',
   },
   polaris: {
-    file: 'tiff_stack_examples/MERFISH_example_RGB.png',
+    file: 'tiff_stack_examples/20220601-MERFISH_example_RGB.png',
     name: 'Polaris',
     model:
       'Polaris performs fluorescent spot detection and can assign spots to segmented cells.',


### PR DESCRIPTION
This PR updates the file name for the Polaris example prediction to temporarily address [this issue](https://github.com/vanvalenlab/kiosk-console/issues/458). It also changes the preset suggested channel order for the Polaris job card. 