### PR TITLE
Switch all visualizers to label.deepcell.org

### DIFF
--- a/src/Predict/JobCompleteButtons/VisualizeButton.js
+++ b/src/Predict/JobCompleteButtons/VisualizeButton.js
@@ -18,7 +18,7 @@ function VisualizeButton({ url, imagesUrl, dimensionOrder, labelsUrl }) {
       headers: { 'Content-Type': 'multipart/form-data' },
     })
       .then((res) => {
-        newTab.location.href = `${url}/project?projectId=${res.data}`;
+        newTab.location.href = `${url}/project?projectId=${res.data}&download=true`;
       })
       .catch((err) => {
         console.log(err);

--- a/src/Predict/JobCompleteButtons/VisualizeButton.js
+++ b/src/Predict/JobCompleteButtons/VisualizeButton.js
@@ -10,24 +10,20 @@ function VisualizeButton({ url, imagesUrl, dimensionOrder, labelsUrl }) {
     formData.append('labels', labelsUrl);
     formData.append('axes', dimensionOrder);
 
-    // TODO: make mesmer and spots visualizers behave consistently
-    // mesmer (viewer.deepcell.org): must be only base URL
-    // spots, tracks, label, anolytics: need to add /project
-    const viewerUrl = url.includes('viewer') ? url : `${url}/project`;
-    const newTab = window.open(viewerUrl, '_blank');
+    const newTab = window.open(`${url}/loading`, '_blank');
     axios({
       method: 'post',
       url: `${url}/api/project`,
       data: formData,
       headers: { 'Content-Type': 'multipart/form-data' },
-    }).then((res) => {
-      // TODO: make mesmer and spots API return the same response
-      // memser: { projectId: "EXAMPLEID" }
-      // spots: "EXAMPLEID"
-      const projectId = res.data.projectId ?? res.data;
-      const projectUrl = `${viewerUrl}?projectId=${projectId}`;
-      newTab.location.href = projectUrl;
-    });
+    })
+      .then((res) => {
+        newTab.location.href = `${url}/project?projectId=${res.data}`;
+      })
+      .catch((err) => {
+        console.log(err);
+        newTab.location.href = `${url}/loading?error=${err.message}`;
+      });
   };
 
   return (

--- a/src/Predict/Predict.js
+++ b/src/Predict/Predict.js
@@ -29,6 +29,12 @@ export default function Predict() {
   const [status, setStatus] = useState('');
   const [jobForm, setJobForm] = useState({});
 
+  useEffect(() => {
+    if (!submitted) {
+      setDimensionOrder(jobForm.dimensionOrder);
+    }
+  }, [submitted, jobForm]);
+
   const expireRedisHash = (redisHash, expireIn) => {
     axios({
       method: 'post',
@@ -80,7 +86,9 @@ export default function Predict() {
           } else if (response.data.value[0] === 'done') {
             clearInterval(statusCheck);
             setLabelsUrl(response.data.value[2]);
-            setDimensionOrder(response.data.value[5]);
+            if (response.data.value[5]) {
+              setDimensionOrder(response.data.value[5]);
+            }
             expireRedisHash(redisHash, 3600);
             // This is only used during zip uploads.
             // Some jobs may fail while other jobs can succeed.

--- a/src/Predict/jobData.js
+++ b/src/Predict/jobData.js
@@ -27,7 +27,7 @@ const jobCards = {
     channelEnabled: false, // Caliban form does not have a channel form so this value doesn't matter
     requiredChannels: ['nuclei'],
     modelResolution: 0.5,
-    visualizer: 'https://tracks.deepcell.org',
+    visualizer: 'https://label-dev.deepcell.org',
   },
   mesmer: {
     file: 'tiff_stack_examples/vectra_breast_cancer.tif',
@@ -41,7 +41,7 @@ const jobCards = {
     channelEnabled: true,
     requiredChannels: ['nuclei', 'cytoplasm'],
     modelResolution: 0.5,
-    visualizer: 'https://viewer.deepcell.org',
+    visualizer: 'https://label-dev.deepcell.org',
   },
   polaris: {
     file: 'tiff_stack_examples/20220601-MERFISH_example_RGB.png',
@@ -57,7 +57,7 @@ const jobCards = {
     channelEnabled: false,
     requiredChannels: ['spots'],
     modelResolution: 0.1,
-    visualizer: 'https://spots.deepcell.org',
+    visualizer: 'https://label-dev.deepcell.org',
   },
 };
 

--- a/src/Predict/jobData.js
+++ b/src/Predict/jobData.js
@@ -12,6 +12,7 @@ const jobCards = {
     channelEnabled: true,
     requiredChannels: [],
     modelResolution: 0.5,
+    visualizer: 'https://label-dev.deepcell.org',
   },
   caliban: {
     file: 'tiff_stack_examples/3T3_nuc_example_256.tif',

--- a/src/Predict/jobData.js
+++ b/src/Predict/jobData.js
@@ -12,7 +12,7 @@ const jobCards = {
     channelEnabled: true,
     requiredChannels: [],
     modelResolution: 0.5,
-    visualizer: 'https://label-dev.deepcell.org',
+    visualizer: 'https://label.deepcell.org',
   },
   caliban: {
     file: 'tiff_stack_examples/3T3_nuc_example_256.tif',
@@ -28,7 +28,7 @@ const jobCards = {
     channelEnabled: false, // Caliban form does not have a channel form so this value doesn't matter
     requiredChannels: ['nuclei'],
     modelResolution: 0.5,
-    visualizer: 'https://label-dev.deepcell.org',
+    visualizer: 'https://label.deepcell.org',
   },
   mesmer: {
     file: 'tiff_stack_examples/vectra_breast_cancer.tif',
@@ -42,7 +42,7 @@ const jobCards = {
     channelEnabled: true,
     requiredChannels: ['nuclei', 'cytoplasm'],
     modelResolution: 0.5,
-    visualizer: 'https://label-dev.deepcell.org',
+    visualizer: 'https://label.deepcell.org',
   },
   polaris: {
     file: 'tiff_stack_examples/20220601-MERFISH_example_RGB.png',
@@ -58,7 +58,7 @@ const jobCards = {
     channelEnabled: false,
     requiredChannels: ['spots'],
     modelResolution: 0.1,
-    visualizer: 'https://label-dev.deepcell.org',
+    visualizer: 'https://label.deepcell.org',
   },
 };
 


### PR DESCRIPTION
This switches all the visualizers to use DeepCell Label with editing enabled.

It also adds visualizer support for the segmentation model. As the segmentation consumer supports different dimension orders, we need to pass this dimension order to DCL to load the images properly. The mesmer redis consumer already sends a dimension order that is forwarded to DCL. I've wired an effect to update the dimension order when the jobForm changes, but this is a bit hacked together and should be revisited as we support flexible dimension orders for more models.

- [x] At the moment, the visualizers are set to label-dev.deepcell.org. Before merging, we should change them to label.deepcell.org after we release 0.4 for deepcell label and put it online.

Merging this will let us take viewer.deepcell.org, spots.deepcell.org, and tracks.deepcell.org offline and close https://github.com/vanvalenlab/deepcell-label/pull/243.